### PR TITLE
feat: 배송 시작 API 구현 및 배송 생성 시 이벤트 발행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,229 @@
-.idea/*
+# Created by https://www.toptal.com/developers/gitignore/api/gradle,java,intellij,macos,windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle,java,intellij,macos,windows
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Gradle Patch ###
+# Java heap dump
+*.hprof
+
+# End of https://www.toptal.com/developers/gitignore/api/gradle,java,intellij,macos,windows

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryStartRequestDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryStartRequestDto.java
@@ -1,0 +1,19 @@
+package com.pickple.delivery.application.dto;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliveryStartRequestDto {
+
+    private UUID deliveryId;
+
+    private String carrierName;
+
+    private String deliveryType;
+
+    private String trackingNumber;
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryStartResponseDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryStartResponseDto.java
@@ -3,15 +3,23 @@ package com.pickple.delivery.application.dto;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import java.util.UUID;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
-public class DeliveryCreateResponseDto {
+public class DeliveryStartResponseDto {
 
     private UUID deliveryId;
 
     private UUID orderId;
 
-    private DeliveryStatus deliveryStatus;
+    private String carrierName;
+
+    private String  deliveryType;
+
+    private String trackingNumber;
+
+    private String deliveryStatus;
 
     private String deliveryRequirement;
 
@@ -20,5 +28,4 @@ public class DeliveryCreateResponseDto {
     private String recipientAddress;
 
     private String recipientContact;
-
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryStartResponseDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryStartResponseDto.java
@@ -1,6 +1,5 @@
 package com.pickple.delivery.application.dto;
 
-import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;

--- a/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryCreateFailureEvent.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryCreateFailureEvent.java
@@ -1,0 +1,16 @@
+package com.pickple.delivery.application.events;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryCreateFailureEvent {
+
+    private UUID orderId;
+
+    private String errorMessage;
+
+}
+

--- a/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryCreateResponseEvent.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryCreateResponseEvent.java
@@ -1,0 +1,13 @@
+package com.pickple.delivery.application.events;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryCreateResponseEvent {
+
+    private UUID deliveryId;
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
@@ -1,9 +1,12 @@
 package com.pickple.delivery.application.mapper;
 
 import com.pickple.delivery.application.dto.DeliveryCreateRequestDto;
-import com.pickple.delivery.application.dto.DeliveryCreateResponseDto;
+import com.pickple.delivery.application.dto.DeliveryStartRequestDto;
+import com.pickple.delivery.application.dto.DeliveryStartResponseDto;
 import com.pickple.delivery.domain.model.Delivery;
 import com.pickple.delivery.infrastructure.messaging.events.DeliveryCreateRequestEvent;
+import com.pickple.delivery.presentation.request.DeliveryStartRequest;
+import java.util.UUID;
 
 public class DeliveryMapper {
 
@@ -17,17 +20,29 @@ public class DeliveryMapper {
                 .build();
     }
 
-    public static DeliveryCreateResponseDto convertEntityToCreateResponseDto (Delivery delivery) {
-        return DeliveryCreateResponseDto.builder()
+    public static DeliveryStartRequestDto convertStartRequestToDto(UUID deliveryId, DeliveryStartRequest dto) {
+        return DeliveryStartRequestDto.builder()
+                .deliveryId(deliveryId)
+                .carrierName(dto.getCarrierName())
+                .deliveryType(dto.getDeliveryType())
+                .trackingNumber(dto.getTrackingNumber())
+                .build();
+    }
+    public static DeliveryStartResponseDto convertEntityToStartResponseDto(Delivery delivery) {
+        return DeliveryStartResponseDto.builder()
                 .deliveryId(delivery.getDeliveryId())
+                .carrierName(delivery.getCarrierName())
+                .deliveryType(delivery.getDeliveryType().getTypeName())
+                .trackingNumber(delivery.getTrackingNumber())
                 .orderId(delivery.getOrderId())
-                .deliveryStatus(delivery.getDeliveryStatus())
+                .deliveryStatus(delivery.getDeliveryStatus().getStatus())
                 .deliveryRequirement(delivery.getDeliveryRequirement())
                 .recipientName(delivery.getRecipientName())
                 .recipientAddress(delivery.getRecipientAddress())
                 .recipientContact(delivery.getRecipientContact())
                 .build();
     }
+
 
 }
 

--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryApplicationService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryApplicationService.java
@@ -1,15 +1,31 @@
 package com.pickple.delivery.application.service;
 
+import com.pickple.common_module.exception.CommonErrorCode;
+import com.pickple.common_module.exception.CustomException;
+import com.pickple.common_module.infrastructure.messaging.EventSerializer;
 import com.pickple.delivery.application.dto.DeliveryCreateRequestDto;
-import com.pickple.delivery.application.dto.DeliveryCreateResponseDto;
+import com.pickple.delivery.application.events.DeliveryCreateFailureEvent;
+import com.pickple.delivery.application.events.DeliveryCreateResponseEvent;
+import com.pickple.delivery.application.dto.DeliveryStartRequestDto;
+import com.pickple.delivery.application.dto.DeliveryStartResponseDto;
 import com.pickple.delivery.application.mapper.DeliveryMapper;
+import com.pickple.delivery.domain.model.enums.DeliveryCarrier;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.domain.repository.DeliveryRepository;
 import com.pickple.delivery.domain.model.Delivery;
 import com.pickple.delivery.domain.service.DeliveryDomainService;
+import com.pickple.delivery.exception.DeliveryErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
+@Slf4j
 @Service
+@Validated
 @RequiredArgsConstructor
 public class DeliveryApplicationService {
 
@@ -17,12 +33,54 @@ public class DeliveryApplicationService {
 
     private final DeliveryDomainService deliveryDomainService;
 
-    public DeliveryCreateResponseDto createDelivery(
-            DeliveryCreateRequestDto dto) {
-        // TODO: DTO Validator 구현
-        Delivery savedDelivery = deliveryRepository.save(
-                deliveryDomainService.createDelivery(dto));
-        return DeliveryMapper.convertEntityToCreateResponseDto(savedDelivery);
+    private final DeliveryMessageProducerService deliveryMessageProducerService;
+
+    @Value("${kafka.topic.delivery-create-response}")
+    private String deliveryCreateResponseTopic;
+
+    @Value("${kafka.topic.delivery-create-failure}")
+    private String deliveryCreateFailureTopic;
+
+    @Transactional
+    public void createDelivery(@Valid DeliveryCreateRequestDto dto) {
+        Delivery delivery;
+        try {
+            log.info("새로운 Delivery 를 생성합니다. 요청 정보: {}", dto);
+            delivery = deliveryRepository.save(
+                    deliveryDomainService.createDelivery(dto));
+        } catch (Exception e) {
+            log.info("Kafka 실패 메시지를 발행합니다. Topic: {}, 주문 ID: {}", deliveryCreateFailureTopic,
+                    dto.getOrderId());
+            DeliveryCreateFailureEvent failureEvent = new DeliveryCreateFailureEvent(
+                    dto.getOrderId(), DeliveryErrorCode.DELIVERY_CREATE_FAILURE.getMessage());
+            deliveryMessageProducerService.sendMessage(deliveryCreateFailureTopic,
+                    EventSerializer.serialize(failureEvent));
+            throw new CustomException(CommonErrorCode.DATABASE_ERROR);
+        }
+        DeliveryCreateResponseEvent deliveryCreateResponseEvent = new DeliveryCreateResponseEvent(
+                delivery.getDeliveryId());
+
+        log.info("Kafka 메시지를 발행합니다. Topic: {}, 배송 ID: {}", deliveryCreateResponseTopic,
+                delivery.getDeliveryId());
+        deliveryMessageProducerService.sendMessage(deliveryCreateResponseTopic,
+                EventSerializer.serialize(deliveryCreateResponseEvent));
+    }
+
+    @Transactional(readOnly = true)
+    public DeliveryStartResponseDto startDelivery(DeliveryStartRequestDto dto) {
+        log.info("배송 시작 요청을 처리합니다. 배송 ID: {}, 택배 회사: {}, 배송 유형: {}", dto.getDeliveryId(),
+                dto.getCarrierName(), dto.getDeliveryType());
+        Delivery delivery = deliveryRepository.findById(dto.getDeliveryId()).orElseThrow(
+                () -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND)
+        );
+
+        String carrierId = DeliveryCarrier.getIdFromCarrierName(dto.getCarrierName())
+                .getCompanyId();
+        DeliveryType deliveryType = DeliveryType.getDeliveryType(dto.getDeliveryType());
+        delivery.startDelivery(carrierId, deliveryType, dto);
+
+        log.info("배송 정보가 성공적으로 업데이트되었습니다. 배송 ID: {}", delivery.getDeliveryId());
+        return DeliveryMapper.convertEntityToStartResponseDto(deliveryRepository.save(delivery));
     }
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryMessageProducerService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryMessageProducerService.java
@@ -1,7 +1,20 @@
 package com.pickple.delivery.application.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class DeliveryMessageProducerService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendMessage(String topic, String message) {
+        log.info("Kafka 메시지를 발행합니다. Topic: {}, 메시지: {}", topic, message);
+        kafkaTemplate.send(topic, message);
+    }
+
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
@@ -1,5 +1,6 @@
 package com.pickple.delivery.domain.model;
 
+import com.pickple.delivery.application.dto.DeliveryStartRequestDto;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.model.enums.DeliveryType;
 import java.util.UUID;
@@ -69,6 +70,19 @@ public class Delivery extends BaseEntity implements Persistable<UUID> {
     @Override
     public boolean isNew() {
         return getCreatedAt() == null;
+    }
+
+    public void startDelivery (String carrierId, DeliveryType deliveryType,
+            DeliveryStartRequestDto dto) {
+        this.deliveryStatus = DeliveryStatus.IN_TRANSIT;
+        this.carrierId = carrierId;
+        this.deliveryType = deliveryType;
+        this.carrierName = dto.getCarrierName();
+        this.trackingNumber = dto.getTrackingNumber();
+    }
+
+    public void delete() {
+        this.isDelete = true;
     }
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryCarrier.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryCarrier.java
@@ -1,0 +1,33 @@
+package com.pickple.delivery.domain.model.enums;
+
+import com.pickple.common_module.exception.CustomException;
+import com.pickple.delivery.exception.DeliveryErrorCode;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * {@code companyId} 는 배송 추적 API에서 제공되는 carrierId로, 예를 들어 "kr.logen"은 로젠택배를 의미합니다.
+ * 자세한 사항은 <a href="https://tracker.delivery/docs/tracking-api#carriers-search">Carrier API 문서</a>를 참고하세요.
+ */
+@Getter
+@AllArgsConstructor
+public enum DeliveryCarrier {
+
+    LOZEN("로젠택배",  "kr.logen"),
+    CJ_LOGISTICS("CJ대한통운", "kr.cjlogistics"),
+    HAJIN("한진택배", "kr.hanjin"),
+    EPOST("우체국택배", "kr.epost");
+
+    private final String companyName;
+
+    private final String companyId;
+
+    public static DeliveryCarrier getIdFromCarrierName(String name) {
+        return Arrays.stream(values())
+                .filter(company -> company.companyName.equals(name))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(DeliveryErrorCode.CARRIER_NAME_NOT_SUPPORT));
+    }
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryStatus.java
@@ -1,5 +1,8 @@
 package com.pickple.delivery.domain.model.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * 배송 상태를 나타내는 ENUM 클래스입니다.
  *
@@ -9,8 +12,12 @@ package com.pickple.delivery.domain.model.enums;
  *   <li>DELIVERED - 배송 완료</li>
  * </ul>
  */
+@Getter
+@AllArgsConstructor
 public enum DeliveryStatus {
-    PENDING,
-    IN_TRANSIT,
-    DELIVERED
+    PENDING("배송준비중"),
+    IN_TRANSIT("배송중"),
+    DELIVERED("배송완료");
+
+    private final String status;
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryType.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryType.java
@@ -1,16 +1,34 @@
 package com.pickple.delivery.domain.model.enums;
 
+import com.pickple.common_module.exception.CustomException;
+import com.pickple.delivery.exception.DeliveryErrorCode;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * 배송 유형을 나타내는 ENUM 클래스입니다.
  *
  * <ul>
- *   <li>PICKUP - 직접 수령</li>
+ *   <li>DIRECT - 직접 배송</li>
  *   <li>COURIER - 택배 배송</li>
  *   <li>EXPRESS - 익일 특급 배송</li>
  * </ul>
  */
+@Getter
+@AllArgsConstructor
 public enum DeliveryType {
-    PICKUP,
-    COURIER,
-    EXPRESS,
+
+    DIRECT("직접 배송"),
+    COURIER("택배 배송"),
+    EXPRESS("익일 특급 배송");
+
+    private final String typeName;
+
+    public static DeliveryType getDeliveryType(String name) {
+        return Arrays.stream(values())
+                .filter(type -> type.getTypeName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_TYPE_NOT_SUPPORT));
+    }
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
@@ -1,9 +1,13 @@
 package com.pickple.delivery.domain.repository;
 
 import com.pickple.delivery.domain.model.Delivery;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface DeliveryRepository {
 
     <S extends Delivery> S save(S entity);
+
+    Optional<Delivery> findById(UUID uuid);
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
@@ -1,0 +1,28 @@
+package com.pickple.delivery.exception;
+
+import com.pickple.common_module.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum DeliveryErrorCode implements ErrorCode {
+
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 배송입니다."),
+    CARRIER_NAME_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 택배사 입니다."),
+    DELIVERY_TYPE_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 배송 방식 입니다."),
+    INVALID_MESSAGE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 메시지 형식입니다."),
+    DELIVERY_CREATE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Delivery 생성에 실패하였습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryExceptionHandler.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.pickple.delivery.exception;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.pickple.common_module.exception.CommonErrorCode;
+import com.pickple.common_module.exception.CustomException;
+import com.pickple.common_module.exception.ErrorResponse;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
+import java.util.Arrays;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@RestControllerAdvice
+public class DeliveryExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> customExceptionHandler(CustomException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.error(e.getErrorCode()));
+    }
+
+    // @Valid 검증에 대한 에러 출력
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodNotValidExceptionHandler(MethodArgumentNotValidException e) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .message(e.getMessage())
+                .build();
+        e.getBindingResult().getFieldErrors().forEach(error -> {
+            errorResponse.addValidation(error.getField(), error.getDefaultMessage());
+        });
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> httpMessageNotReadableExceptionHandler(HttpMessageNotReadableException ex, WebRequest request) {
+        Throwable rootCause = ex.getCause();
+        if (rootCause instanceof InvalidFormatException invalidFormatException) {
+            String fieldName = invalidFormatException.getPath().get(0).getFieldName();
+            String invalidValue = invalidFormatException.getValue().toString();
+            String message = String.format("유효하지 않는 '%s' 값입니다. '%s' 는 %s 중 하나이어야 합니다.",
+                    invalidValue, fieldName, Arrays.toString(DeliveryType.values()));
+            return ResponseEntity.badRequest().body(message);
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(CommonErrorCode.INVALID_INPUT_VALUE);
+    }
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/config/SecurityConfig.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.pickple.delivery.infrastructure.config;
+
+import com.pickple.delivery.infrastructure.security.CustomAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final CustomAuthenticationFilter customAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.addFilterBefore(customAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class);
+
+        http.authorizeHttpRequests(authorize ->
+                authorize.anyRequest().authenticated()
+        );
+        return http.build();
+    }
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/messaging/DeliveryMessageConsumerService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/messaging/DeliveryMessageConsumerService.java
@@ -3,9 +3,10 @@ package com.pickple.delivery.infrastructure.messaging;
 import static com.pickple.common_module.infrastructure.messaging.EventSerializer.objectMapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.pickple.delivery.application.dto.DeliveryCreateResponseDto;
+import com.pickple.common_module.exception.CustomException;
 import com.pickple.delivery.application.mapper.DeliveryMapper;
 import com.pickple.delivery.application.service.DeliveryApplicationService;
+import com.pickple.delivery.exception.DeliveryErrorCode;
 import com.pickple.delivery.infrastructure.messaging.events.DeliveryCreateRequestEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,19 +20,22 @@ public class DeliveryMessageConsumerService {
 
     private final DeliveryApplicationService deliveryApplicationService;
 
-    @KafkaListener(topics = "delivery-service-create")
+    // TODO: Kafka errorHandler 구현
+    @KafkaListener(topics = "delivery-create-request", groupId = "delivery-group")
     public void consumeDeliveryCreation(String message) {
-        log.info("메세지 도착: {}", message);
+
+        DeliveryCreateRequestEvent deliveryCreateRequestEvent;
         try {
-            DeliveryCreateRequestEvent deliveryCreateRequestEvent = objectMapper.readValue(message,
+            deliveryCreateRequestEvent = objectMapper.readValue(message,
                     DeliveryCreateRequestEvent.class);
-            DeliveryCreateResponseDto delivery = deliveryApplicationService.createDelivery(
-                    DeliveryMapper.convertCreateRequestEventToDto(deliveryCreateRequestEvent));
-            // TODO: Order 로 이벤트 발행?
         } catch (JsonProcessingException e) {
-            // TODO: Exception Handler 구현
+            // TODO: Exception Handler 구현하여 throw Exception이 아니라 ErrorEvent를 발행해야 합니다.
             log.error("유효하지 않은 메시지 형식입니다.: {}", message, e);
+            throw new CustomException(DeliveryErrorCode.INVALID_MESSAGE_FORMAT);
         }
+
+        deliveryApplicationService.createDelivery(
+                DeliveryMapper.convertCreateRequestEventToDto(deliveryCreateRequestEvent));
     }
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryCassandraRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryCassandraRepository.java
@@ -3,6 +3,7 @@ package com.pickple.delivery.infrastructure.repository;
 import com.pickple.delivery.domain.repository.DeliveryRepository;
 import com.pickple.delivery.domain.model.Delivery;
 import jakarta.annotation.Nonnull;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.cassandra.repository.CassandraRepository;
 
@@ -10,5 +11,8 @@ public interface DeliveryCassandraRepository extends DeliveryRepository, Cassand
 
     @Override
     <S extends Delivery> @Nonnull S save(@Nonnull S entity);
+
+    @Override
+    @Nonnull Optional<Delivery> findById(@Nonnull UUID uuid);
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/security/CustomAuthenticationFilter.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/security/CustomAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.pickple.delivery.infrastructure.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class CustomAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String username = request.getHeader("X-User-Name");
+        String roles = request.getHeader("X-User-Roles");
+
+        if (username != null && roles != null) {
+            List<SimpleGrantedAuthority> authorities = Arrays.stream(roles.split(","))
+                    .map(role -> new SimpleGrantedAuthority(role.trim()))
+                    .toList();
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    username,
+                    null,
+                   authorities
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -31,4 +31,4 @@ public class DeliveryController {
                 DeliveryMapper.convertStartRequestToDto(deliveryId, request)));
     }
 
-};
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -1,0 +1,34 @@
+package com.pickple.delivery.presentation.controller;
+
+import com.pickple.common_module.presentation.dto.ApiResponse;
+import com.pickple.delivery.application.dto.DeliveryStartResponseDto;
+import com.pickple.delivery.application.mapper.DeliveryMapper;
+import com.pickple.delivery.application.service.DeliveryApplicationService;
+import com.pickple.delivery.presentation.request.DeliveryStartRequest;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/deliveries")
+@RequiredArgsConstructor
+public class DeliveryController {
+
+    private final DeliveryApplicationService deliveryService;
+
+    @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
+    @PostMapping("/{delivery_id}/start")
+    public ApiResponse<DeliveryStartResponseDto> startDelivery(@PathVariable("delivery_id") UUID deliveryId,
+            @Valid @RequestBody DeliveryStartRequest request) {
+        return ApiResponse.success(HttpStatus.OK, "배송이 등록되었습니다.", deliveryService.startDelivery(
+                DeliveryMapper.convertStartRequestToDto(deliveryId, request)));
+    }
+
+};

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/request/DeliveryStartRequest.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/request/DeliveryStartRequest.java
@@ -1,0 +1,18 @@
+package com.pickple.delivery.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeliveryStartRequest {
+
+    @NotBlank
+    private String carrierName;
+
+    @NotBlank
+    private String deliveryType;
+
+    @NotBlank
+    private String trackingNumber;
+
+}

--- a/delivery-service/src/main/resources/application-dev.yml
+++ b/delivery-service/src/main/resources/application-dev.yml
@@ -16,13 +16,20 @@ spring:
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
     register-with-eureka: true
     fetch-registry: true
+
+kafka:
+  topic:
+    delivery-create-response: delivery-create-response
+    delivery-create-failure: delivery-create-failure
 
 server:
   port: 19096


### PR DESCRIPTION
- resolve #37 

## 📌 필독 내용

- 배송 생성 성공 시 Order에 응답할 kafka topic은 `delivery-create-response`, 배송 생성 실패 시 `delivery-create-failure` 입니다.
- `.gitignore`을 root 디렉토리에 추가했습니다. ([여기](https://www.toptal.com/developers/gitignore)서 만들었습니다)
- 배송 시작 시 API를 구현했습니다.

</br>

## ✨ PR 세부 내용

- Spring Security 필터 구현
- 배송 생성 api 엔드포인트: `/api/v1/deliveries/{delivery_id}/start` 
예시 body json
```json
{
    "carrierName": "로젠택배",
    "deliveryType": "택배 배송",
    "trackingNumber": "1234131421"
}
```
