### PR TITLE
feat: Payment에 Kafka 메세징 처리 구현

### DIFF
--- a/payment-service/src/main/java/com/pickple/payment_service/application/dto/PaymentRespDto.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/application/dto/PaymentRespDto.java
@@ -13,16 +13,18 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PaymentRespDto {
-    private UUID paymentId;
     private UUID orderId;
+    private UUID paymentId;
+    private String userName;
     private BigDecimal amount;
     private String method;
     private PaymentStatusEnum status;
 
     public static PaymentRespDto from(Payment payment) {
         return PaymentRespDto.builder()
-                .paymentId(payment.getPaymentId())
                 .orderId(payment.getOrderId())
+                .paymentId(payment.getPaymentId())
+                .userName(payment.getUserName())
                 .amount(payment.getAmount())
                 .method(payment.getMethod())
                 .status(payment.getStatus())

--- a/payment-service/src/main/java/com/pickple/payment_service/application/service/PaymentEventService.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/application/service/PaymentEventService.java
@@ -2,8 +2,10 @@ package com.pickple.payment_service.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickple.common_module.infrastructure.messaging.EventSerializer;
-import com.pickple.payment_service.infrastructure.messaging.events.PaymentSuccessEvent;
-import jdk.jfr.Event;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCancelFailureEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCancelResponseEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCreateFailureEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCreateResponseEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -15,8 +17,20 @@ public class PaymentEventService {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final ObjectMapper mapper = new ObjectMapper();
 
-    public void sendPaymentSuccessEvent(PaymentSuccessEvent event) {
+    public void sendCreateSuccessEvent(PaymentCreateResponseEvent event) {
         kafkaTemplate.send("payment-create-response", EventSerializer.serialize(event));
+    }
+
+    public void sendCreateFailureEvent(PaymentCreateFailureEvent event){
+        kafkaTemplate.send("payment-create-failure", EventSerializer.serialize(event));
+    }
+
+    public void sendCancelSuccessEvent(PaymentCancelResponseEvent event) {
+        kafkaTemplate.send("payment-cancel-response", EventSerializer.serialize(event));
+    }
+
+    public void sendCancelFailureEvent(PaymentCancelFailureEvent event){
+        kafkaTemplate.send("payment-cancel-failure", EventSerializer.serialize(event));
     }
 
 }

--- a/payment-service/src/main/java/com/pickple/payment_service/application/service/PaymentService.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/application/service/PaymentService.java
@@ -5,6 +5,9 @@ import com.pickple.common_module.exception.CustomException;
 import com.pickple.payment_service.application.dto.PaymentRespDto;
 import com.pickple.payment_service.domain.model.Payment;
 import com.pickple.payment_service.domain.repository.PaymentRepository;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCancelFailureEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCancelResponseEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCreateFailureEvent;
 import com.pickple.payment_service.infrastructure.messaging.events.PaymentCreateResponseEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,32 +30,58 @@ public class PaymentService {
     // 결제 생성
     @Transactional
     public void createPayment(UUID orderId, String userName, BigDecimal amount) {
-        Payment payment = new Payment(orderId, userName, amount);
-        paymentRepository.save(payment);
-        // 결제 대기 처리
+        // Kafka 메세지 검증
+        if(orderId == null || userName == null || amount == null) {
+            throw new CustomException(PaymentErrorCode.INVALID_MESSAGE_FORMAT);
+        }
 
+        Payment payment = new Payment(orderId, userName, amount);
+
+        try {
+            // 결제 생성 후 대기 처리
+            paymentRepository.save(payment);
+        } catch(Exception e){
+            PaymentCreateFailureEvent event = new PaymentCreateFailureEvent(orderId);
+            paymentEventService.sendCreateFailureEvent(event);
+            throw new CustomException(PaymentErrorCode.PAYMENT_CREATE_FAILED);
+        }
+
+        // 결제 완료 처리
         payment.success();
         paymentRepository.save(payment);
-        // 결제 완료 처리
 
-        PaymentCreateResponseEvent event = new PaymentCreateResponseEvent(payment.getPaymentId(), payment.getStatus());
-        paymentEventService.sendPaymentSuccessEvent(event);
+        PaymentCreateResponseEvent event = new PaymentCreateResponseEvent(payment.getOrderId(), payment.getPaymentId());
+        paymentEventService.sendCreateSuccessEvent(event);
 
     }
 
     // 결제 취소 처리
     @Transactional
-    public void cancelPayment(UUID orderId, String status){
-        // errorEvent 만들고 난 뒤에 검증 처리 추가 예정
+    public void cancelPayment(UUID orderId){
+        // Kafka 메세지 검증
+        if(orderId == null) {
+            throw new CustomException(PaymentErrorCode.INVALID_MESSAGE_FORMAT);
+        }
+
         Payment payment = paymentRepository.findByOrderIdAndIsDeleteIsFalse(orderId).orElseThrow(
                 () -> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND)
         );
 
-        payment.canceled();
-        paymentRepository.save(payment);
+        try {
+            // 결제 취소
+            payment.canceled();
+            paymentRepository.save(payment);
+        } catch(Exception e){
+            PaymentCancelFailureEvent event = new PaymentCancelFailureEvent(orderId);
+            paymentEventService.sendCancelFailureEvent(event);
+            throw new CustomException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
+        }
+
+        PaymentCancelResponseEvent event = new PaymentCancelResponseEvent(payment.getOrderId(), payment.getPaymentId());
+        paymentEventService.sendCancelSuccessEvent(event);
     }
 
-    // 결제 상세 조회
+    // 결제 단건 조회
     @Transactional(readOnly = true)
     public PaymentRespDto getPaymentDetails (UUID paymentId){
         Payment payment = paymentRepository.findByPaymentIdAndIsDeleteIsFalse(paymentId).orElseThrow(
@@ -64,7 +93,7 @@ public class PaymentService {
 
     // 결제 전체 조회 (user)
     @Transactional(readOnly = true)
-    public Page<PaymentRespDto> getPaymentByUser(String userName, Pageable pageable) {
+    public Page<PaymentRespDto> getPaymentsByUser(String userName, Pageable pageable) {
         Page<Payment> paymentList = paymentRepository.findAllByUserNameAndIsDeleteIsFalse(userName, pageable).orElseThrow(
                 ()-> new CustomException(PaymentErrorCode.PAYMENT_NOT_FOUND)
         );

--- a/payment-service/src/main/java/com/pickple/payment_service/domain/model/Payment.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/domain/model/Payment.java
@@ -23,8 +23,8 @@ public class Payment extends BaseEntity {
     @Column(name="order_id")
     private UUID orderId;
 
-    @Column(name="user_id")
-    private Long userId;
+    @Column(name="username")
+    private String userName;
 
     @Column(name="amount")
     private BigDecimal amount;
@@ -36,10 +36,10 @@ public class Payment extends BaseEntity {
     @Enumerated(value=EnumType.STRING)
     private PaymentStatusEnum status;
 
-    public Payment(UUID orderId, Long userId, BigDecimal amount) {
+    public Payment(UUID orderId, String userName, BigDecimal amount) {
         this.orderId = orderId;
         this.amount = amount;
-        this.userId = userId;
+        this.userName = userName;
         this.method = "CREDIT-CARD";
         this.status = PaymentStatusEnum.PENDING;
     }

--- a/payment-service/src/main/java/com/pickple/payment_service/domain/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/domain/repository/PaymentRepository.java
@@ -11,6 +11,6 @@ import java.util.UUID;
 public interface PaymentRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findByOrderIdAndIsDeleteIsFalse(UUID orderId);
     Optional<Payment> findByPaymentIdAndIsDeleteIsFalse(UUID paymentId);
-    Optional<Page<Payment>> findAllByUserIdAndIsDeleteIsFalse(Long userId, Pageable pageable);
-    Optional<Page<Payment>> findAllByIsDeleteIsFalse(Long userId, Pageable pageable);
+    Optional<Page<Payment>> findAllByUserNameAndIsDeleteIsFalse(String userName, Pageable pageable);
+    Optional<Page<Payment>> findAllByIsDeleteIsFalse(Pageable pageable);
 }

--- a/payment-service/src/main/java/com/pickple/payment_service/exception/PaymentErrorCode.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/exception/PaymentErrorCode.java
@@ -7,8 +7,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PaymentErrorCode implements ErrorCode {
 
-    // 결제 ID 관련 에러
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID에 해당하는 결제를 찾을 수 없습니다.");
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 결제 내역을 찾을 수 없습니다."),
+    INVALID_MESSAGE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 메시지 형식입니다."),
+    PAYMENT_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 생성에 실패했습니다." ),
+    PAYMENT_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 취소에 실패했습니다." );
 
     private final HttpStatus status;
     private final String message;

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/PaymentEventConsumer.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/PaymentEventConsumer.java
@@ -2,8 +2,8 @@ package com.pickple.payment_service.infrastructure.messaging;
 
 import com.pickple.common_module.infrastructure.messaging.EventSerializer;
 import com.pickple.payment_service.application.service.PaymentService;
-import com.pickple.payment_service.infrastructure.messaging.events.OrderCreatedEvent;
-import com.pickple.payment_service.infrastructure.messaging.events.PaymentCanceledEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCancelRequestEvent;
+import com.pickple.payment_service.infrastructure.messaging.events.PaymentCreateRequestEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -15,14 +15,14 @@ public class PaymentEventConsumer {
     private final PaymentService paymentService;
 
     @KafkaListener(topics="payment-create-request", groupId="payment-group")
-    public void handleOrderCreated(String message) {
-        OrderCreatedEvent event = EventSerializer.deserialize(message, OrderCreatedEvent.class);
-        paymentService.createPayment(event.getOrderId(), event.getUserId(), event.getAmount());
+    public void handleCreateRequest(String message) {
+        PaymentCreateRequestEvent event = EventSerializer.deserialize(message, PaymentCreateRequestEvent.class);
+        paymentService.createPayment(event.getOrderId(), event.getUserName(), event.getAmount());
     }
 
     @KafkaListener(topics="payment-cancel-request", groupId="payment-group")
-    public void handlePaymentCanceled(String message) {
-        PaymentCanceledEvent event = EventSerializer.deserialize(message, PaymentCanceledEvent.class);
-        paymentService.cancelPayment(event.getOrderId(), event.getStatus());
+    public void handleCancelRequest(String message) {
+        PaymentCancelRequestEvent event = EventSerializer.deserialize(message, PaymentCancelRequestEvent.class);
+        paymentService.cancelPayment(event.getOrderId());
     }
 }

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCancelFailureEvent.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCancelFailureEvent.java
@@ -1,0 +1,23 @@
+package com.pickple.payment_service.infrastructure.messaging.events;
+
+import com.pickple.payment_service.exception.PaymentErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentCancelFailureEvent {
+    private UUID orderId;
+    private String message = "Failed to cancel payment for this order due to an error";
+    private String errorCode = PaymentErrorCode.PAYMENT_CANCEL_FAILED.getStatus().toString();
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    public PaymentCancelFailureEvent(UUID orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCancelRequestEvent.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCancelRequestEvent.java
@@ -4,14 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
-public class OrderCreatedEvent {
+@AllArgsConstructor
+public class PaymentCancelRequestEvent {
     private UUID orderId;
-    private Long userId;
-    private BigDecimal amount;
+    private String message = "Request payment cancellation due to order cancellation.";
 }

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCancelResponseEvent.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCancelResponseEvent.java
@@ -1,0 +1,21 @@
+package com.pickple.payment_service.infrastructure.messaging.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentCancelResponseEvent {
+    private UUID orderId;
+    private UUID paymentId;
+    private String status = "CANCELED";
+
+    public PaymentCancelResponseEvent(UUID orderId, UUID paymentId) {
+        this.orderId = orderId;
+        this.paymentId = paymentId;
+    }
+}

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCreateFailureEvent.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCreateFailureEvent.java
@@ -1,0 +1,23 @@
+package com.pickple.payment_service.infrastructure.messaging.events;
+
+import com.pickple.payment_service.exception.PaymentErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentCreateFailureEvent {
+    private UUID orderId;
+    private String message = "Failed to create order due to an error";
+    private String errorCode = PaymentErrorCode.PAYMENT_CREATE_FAILED.getStatus().toString();
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    public PaymentCreateFailureEvent(UUID orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCreateRequestEvent.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCreateRequestEvent.java
@@ -4,12 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class PaymentCanceledEvent {
+public class PaymentCreateRequestEvent {
     private UUID orderId;
-    private String status;
+    private String userName;
+    private BigDecimal amount;
+    private String message = "Request payment creation for a new order.";
 }

--- a/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCreateResponseEvent.java
+++ b/payment-service/src/main/java/com/pickple/payment_service/infrastructure/messaging/events/PaymentCreateResponseEvent.java
@@ -10,7 +10,13 @@ import java.util.UUID;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class PaymentSuccessEvent {
+public class PaymentCreateResponseEvent {
+    private UUID orderId;
     private UUID paymentId;
-    private PaymentStatusEnum status;
+    private String status = "COMPLETED";
+
+    public PaymentCreateResponseEvent(UUID orderId, UUID paymentId) {
+        this.orderId = orderId;
+        this.paymentId = paymentId;
+    }
 }


### PR DESCRIPTION
## 📌 필독 내용

- Payment에 Kafka 메세징 처리 구현 완료


## ✨ PR 세부 내용

- Kafka 토픽 별로 event 수정 및 추가
   - 결제 생성 성공/실패 시 event 분리
   - 결제 취소 성공/실패 시 event 분리
   - 메세지 검증 과정 구현
- PaymentErrorCode 추가 후 Kafka event에 반영
- Payment 엔티티 userId → username 수정
