### PR TITLE
docs: Grafana & Prometheus 연동을 위한 설정 파일 추가 및 수정

### DIFF
--- a/.github/prometheus/config/prometheus.yml
+++ b/.github/prometheus/config/prometheus.yml
@@ -1,0 +1,86 @@
+global:
+  scrape_interval: 10s
+  scrape_timeout: 10s
+  evaluation_interval: 2m
+
+scrape_configs:
+  - job_name: 'eureka-server'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19090']
+        labels:
+          service: 'server'
+
+  - job_name: 'gateway'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19091']
+        labels:
+          service: 'gateway'
+
+  - job_name: 'auth-service'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19092']
+        labels:
+          service: 'auth'
+
+  - job_name: 'user-service'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19093']
+        labels:
+          service: 'user'
+
+  - job_name: 'commerce-service'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19094']
+        labels:
+          service: 'commerce'
+
+  - job_name: 'payment-service'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19095']
+        labels:
+          service: 'payment'
+
+  - job_name: 'delivery-service'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19096']
+        labels:
+          service: 'delivery'
+
+  - job_name: 'notification-service'
+    metrics_path: '/actuator/prometheus'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:19097']
+        labels:
+          service: 'notification'
+
+  - job_name: 'node-exporter'
+    metrics_path: '/metrics'
+    scheme: 'http'
+
+    static_configs:
+      - targets: ['host.docker.internal:9100']
+        labels:
+          service: 'node-exporter'

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+	// Prometheus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/auth-service/src/main/resources/application-dev.yml
+++ b/auth-service/src/main/resources/application-dev.yml
@@ -14,3 +14,14 @@ spring:
 service:
   jwt:
     secret-key: paieRY4DK8B5jo8NRHQRVo8Ljs2zJgWbEDjbJ3cTVKVac7oftXqVaFmoaC9ouoAp
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/commerce-service/build.gradle
+++ b/commerce-service/build.gradle
@@ -29,6 +29,10 @@ ext {
 }
 
 dependencies {
+    // Prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     implementation project(':common-module')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/commerce-service/src/main/resources/application-dev.yml
+++ b/commerce-service/src/main/resources/application-dev.yml
@@ -20,3 +20,14 @@ eureka:
 
 server:
   port: 19094
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+    // Prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     implementation project(':common-module')
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-cassandra'

--- a/delivery-service/src/main/resources/application-dev.yml
+++ b/delivery-service/src/main/resources/application-dev.yml
@@ -34,3 +34,14 @@ kafka:
 
 server:
   port: 19096
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,3 +99,56 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./.github/prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    ports:
+      - 9090:9090
+    command:
+      - '--storage.tsdb.path=/prometheus'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: always
+    networks:
+      - t4y
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    restart: always
+    depends_on:
+      - prometheus
+    networks:
+      - t4y
+
+  node_exporter:
+    image: prom/node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    ports:
+      - 9100:9100
+    networks:
+      - t4y
+
+networks:
+  t4y:
+    driver: bridge
+
+volumes:
+  grafana-data:
+  prometheus-data:

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -22,6 +22,10 @@ ext {
 }
 
 dependencies {
+	// Prometheus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/eureka-server/src/main/resources/application.yml
+++ b/eureka-server/src/main/resources/application.yml
@@ -13,3 +13,14 @@ eureka:
       defaultZone: http://localhost:19090/eureka
   instance:
     hostname: localhost
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+	// Prometheus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/gateway/src/main/resources/application-dev.yml
+++ b/gateway/src/main/resources/application-dev.yml
@@ -14,3 +14,14 @@ spring:
 service:
   jwt:
     secret-key: paieRY4DK8B5jo8NRHQRVo8Ljs2zJgWbEDjbJ3cTVKVac7oftXqVaFmoaC9ouoAp
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true

--- a/notification-service/src/main/resources/application-dev.yml
+++ b/notification-service/src/main/resources/application-dev.yml
@@ -29,5 +29,19 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
 
+
 server:
   port: 19097
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+
+

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -29,6 +29,10 @@ ext {
 }
 
 dependencies {
+	// Prometheus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// QueryDSL

--- a/user-service/src/main/resources/application-dev.yml
+++ b/user-service/src/main/resources/application-dev.yml
@@ -11,3 +11,14 @@ spring:
     username: user_db
     password: user_db
     driver-class-name: org.postgresql.Driver
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true


### PR DESCRIPTION
## 📌 필독 내용

- Grafana & Prometheus 연동을 위한 설정 파일 추가 및 수정


## ✨ PR 세부 내용

- 각 서비스 마다 의존성 추가 → application.yml & build.gradle
- docker-compose.yml 파일 수정 및 prometheus.yml 파일 추가
- 그라파나-슬랙 연동 완료 → 메시지 포맷, 채널 이름 등 자잘한 설정사항 변경 후 채널 공유 예정


