### PR TITLE
feat: 배송 수정, 검색, 전체 조회 API 구현

### DIFF
--- a/delivery-service/src/main/java/com/pickple/delivery/DeliveryServiceApplication.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/DeliveryServiceApplication.java
@@ -4,9 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })
 @EnableMongoRepositories
+@EnableSpringDataWebSupport(
+        pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO
+)
 public class DeliveryServiceApplication {
 
     public static void main(String[] args) {

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/request/DeliveryStartRequestDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/request/DeliveryStartRequestDto.java
@@ -1,5 +1,7 @@
 package com.pickple.delivery.application.dto.request;
 
+import com.pickple.delivery.domain.model.enums.DeliveryCarrier;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,9 +12,9 @@ public class DeliveryStartRequestDto {
 
     private UUID deliveryId;
 
-    private String carrierName;
+    private DeliveryCarrier deliveryCarrier;
 
-    private String deliveryType;
+    private DeliveryType deliveryType;
 
     private String trackingNumber;
 

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/request/DeliveryUpdateRequestDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/request/DeliveryUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package com.pickple.delivery.application.dto.request;
+
+import com.pickple.delivery.domain.model.enums.DeliveryCarrier;
+import com.pickple.delivery.domain.model.enums.DeliveryStatus;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliveryUpdateRequestDto {
+
+    private DeliveryCarrier carrierName;
+
+    private DeliveryType deliveryType;
+
+    private String trackingNumber;
+
+    private DeliveryStatus deliveryStatus;
+
+    private String deliveryRequirement;
+
+    private String recipientName;
+
+    private String recipientAddress;
+
+    private String recipientContact;
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
@@ -3,12 +3,17 @@ package com.pickple.delivery.application.mapper;
 import com.pickple.delivery.application.dto.request.DeliveryCreateRequestDto;
 import com.pickple.delivery.application.dto.DeliveryDetailInfoDto;
 import com.pickple.delivery.application.dto.DeliveryInfoDto;
+import com.pickple.delivery.application.dto.request.DeliveryUpdateRequestDto;
 import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
 import com.pickple.delivery.application.dto.request.DeliveryStartRequestDto;
 import com.pickple.delivery.application.dto.response.DeliveryStartResponseDto;
 import com.pickple.delivery.domain.model.Delivery;
+import com.pickple.delivery.domain.model.enums.DeliveryCarrier;
+import com.pickple.delivery.domain.model.enums.DeliveryStatus;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.infrastructure.messaging.events.DeliveryCreateRequestEvent;
 import com.pickple.delivery.presentation.request.DeliveryStartRequest;
+import com.pickple.delivery.presentation.request.DeliveryUpdateRequest;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,8 +34,8 @@ public class DeliveryMapper {
             DeliveryStartRequest dto) {
         return DeliveryStartRequestDto.builder()
                 .deliveryId(deliveryId)
-                .carrierName(dto.getCarrierName())
-                .deliveryType(dto.getDeliveryType())
+                .deliveryCarrier(DeliveryCarrier.getFromCarrierName(dto.getCarrierName()))
+                .deliveryType(DeliveryType.getDeliveryType(dto.getDeliveryType()))
                 .trackingNumber(dto.getTrackingNumber())
                 .build();
     }
@@ -79,6 +84,19 @@ public class DeliveryMapper {
                 .recipientName(infoDto.getRecipientName())
                 .trackingNumber(infoDto.getTrackingNumber())
                 .deliveryDetailList(detailInfoDtoList)
+                .build();
+    }
+
+    public static DeliveryUpdateRequestDto convertUpdateRequestToDto(DeliveryUpdateRequest request) {
+        return DeliveryUpdateRequestDto.builder()
+                .carrierName(DeliveryCarrier.getFromCarrierName(request.getCarrierName()))
+                .recipientAddress(request.getRecipientAddress())
+                .deliveryRequirement(request.getDeliveryRequirement())
+                .deliveryStatus(DeliveryStatus.getFromStatus(request.getDeliveryStatus()))
+                .deliveryType(DeliveryType.getDeliveryType(request.getDeliveryType()))
+                .recipientContact(request.getRecipientContact())
+                .recipientName(request.getRecipientName())
+                .trackingNumber(request.getTrackingNumber())
                 .build();
     }
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryDetailApplicationService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryDetailApplicationService.java
@@ -6,6 +6,7 @@ import com.pickple.delivery.application.dto.response.DeliveryDetailCreateRespons
 import com.pickple.delivery.application.mapper.DeliveryDetailMapper;
 import com.pickple.delivery.domain.model.Delivery;
 import com.pickple.delivery.domain.model.DeliveryDetail;
+import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.repository.DeliveryRepository;
 import com.pickple.delivery.exception.DeliveryErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,13 @@ public class DeliveryDetailApplicationService {
             DeliveryDetailCreateRequestDto dto) {
         Delivery delivery = deliveryRepository.findById(dto.getDeliveryId())
                 .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+        if (delivery.getDeliveryStatus() == DeliveryStatus.PENDING) {
+            throw new CustomException(DeliveryErrorCode.DELIVERY_NOT_STARTED);
+        }
+        if (delivery.getDeliveryStatus() == DeliveryStatus.DELIVERED) {
+            throw new CustomException(DeliveryErrorCode.DELIVERY_ALREADY_DELIVERED);
+        }
 
         log.info("새로운 DeliveryDetail 을 생성합니다. 요청 정보: {}", dto);
         DeliveryDetail deliveryDetail = DeliveryDetail.createFrom(dto);

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
@@ -2,6 +2,7 @@ package com.pickple.delivery.domain.model;
 
 import com.pickple.delivery.application.dto.request.DeliveryCreateRequestDto;
 import com.pickple.delivery.application.dto.request.DeliveryStartRequestDto;
+import com.pickple.delivery.application.dto.request.DeliveryUpdateRequestDto;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.model.enums.DeliveryType;
 import java.util.ArrayList;
@@ -82,11 +83,21 @@ public class Delivery extends BaseEntity {
         this.deliveryStatus = DeliveryStatus.IN_TRANSIT;
         this.carrierId = carrierId;
         this.deliveryType = deliveryType;
-        this.carrierName = dto.getCarrierName();
+        this.carrierName = dto.getDeliveryCarrier().getCompanyName();
         this.trackingNumber = dto.getTrackingNumber();
     }
 
     public void addDeliveryDetail(DeliveryDetail detail) {
         this.deliveryDetails.add(detail);
+    }
+
+    public void updateDelivery(DeliveryUpdateRequestDto dto) {
+        this.deliveryStatus = dto.getDeliveryStatus();
+        this.deliveryType = dto.getDeliveryType();
+        this.deliveryRequirement = dto.getDeliveryRequirement();
+        this.trackingNumber = dto.getTrackingNumber();
+        this.recipientName = dto.getRecipientName();
+        this.recipientAddress = dto.getRecipientAddress();
+        this.recipientContact = dto.getRecipientContact();
     }
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryCarrier.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryCarrier.java
@@ -23,7 +23,7 @@ public enum DeliveryCarrier {
 
     private final String companyId;
 
-    public static DeliveryCarrier getIdFromCarrierName(String name) {
+    public static DeliveryCarrier getFromCarrierName(String name) {
         return Arrays.stream(values())
                 .filter(company -> company.companyName.equals(name))
                 .findFirst()

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/enums/DeliveryStatus.java
@@ -1,5 +1,8 @@
 package com.pickple.delivery.domain.model.enums;
 
+import com.pickple.common_module.exception.CustomException;
+import com.pickple.delivery.exception.DeliveryErrorCode;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -20,4 +23,11 @@ public enum DeliveryStatus {
     DELIVERED("배송완료");
 
     private final String status;
+
+    public static DeliveryStatus getFromStatus(String name) {
+        return Arrays.stream(values())
+                .filter(status -> status.getStatus().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_STATUS_NOT_SUPPORT));
+    }
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
@@ -1,9 +1,13 @@
 package com.pickple.delivery.domain.repository;
 
 import com.pickple.delivery.domain.model.Delivery;
+import com.pickple.delivery.domain.model.enums.DeliveryStatus;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
 import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface DeliveryRepository {
 
@@ -11,8 +15,18 @@ public interface DeliveryRepository {
 
     Optional<Delivery> findById(UUID deliveryId);
 
+    Optional<Delivery> findByTrackingNumber(String trackingNumber);
+
     boolean existsById(@Nonnull UUID deliveryId);
 
     void deleteById(UUID deliveryId);
+
+    Page<Delivery> findAll(Pageable pageable);
+
+    Page<Delivery> findByCarrierName(String carrier, Pageable pageable);
+
+    Page<Delivery> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
+
+    Page<Delivery> findByDeliveryType(DeliveryType deliveryType, Pageable pageable);
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
@@ -10,11 +10,16 @@ public enum DeliveryErrorCode implements ErrorCode {
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 배송입니다."),
     CARRIER_NAME_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 택배사 입니다."),
     DELIVERY_TYPE_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 배송 방식 입니다."),
+    DELIVERY_STATUS_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 배송 상태 입니다."),
     TRACKING_NUMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 송장번호 입니다."),
     INVALID_MESSAGE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 메시지 형식입니다."),
     DELIVERY_CREATE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Delivery 생성에 실패하였습니다."),
     DELIVERY_DELETE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Delivery 삭제에 실패하였습니다."),
-    DELIVERY_SAVE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 저장에 실패하였습니다.");
+    DELIVERY_SAVE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 저장에 실패하였습니다."),
+    DELIVERY_ALREADY_START(HttpStatus.BAD_REQUEST, "이미 시작된 배송입니다."),
+    DELIVERY_NOT_STARTED(HttpStatus.BAD_REQUEST, "배송이 아직 시작되지 않았습니다."),
+    DELIVERY_ALREADY_DELIVERED(HttpStatus.BAD_REQUEST, "이미 완료된 배송입니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
@@ -10,6 +10,7 @@ public enum DeliveryErrorCode implements ErrorCode {
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 배송입니다."),
     CARRIER_NAME_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 택배사 입니다."),
     DELIVERY_TYPE_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "지원하지 않는 배송 방식 입니다."),
+    TRACKING_NUMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 송장번호 입니다."),
     INVALID_MESSAGE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 메시지 형식입니다."),
     DELIVERY_CREATE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Delivery 생성에 실패하였습니다."),
     DELIVERY_DELETE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Delivery 삭제에 실패하였습니다."),

--- a/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryExceptionHandler.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryExceptionHandler.java
@@ -4,16 +4,12 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.pickple.common_module.exception.CommonErrorCode;
 import com.pickple.common_module.exception.CustomException;
 import com.pickple.common_module.exception.ErrorResponse;
-import com.pickple.delivery.domain.model.enums.DeliveryType;
-import java.util.Arrays;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
-
 @RestControllerAdvice
 public class DeliveryExceptionHandler {
 
@@ -38,13 +34,11 @@ public class DeliveryExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<?> httpMessageNotReadableExceptionHandler(HttpMessageNotReadableException ex, WebRequest request) {
-        Throwable rootCause = ex.getCause();
+    public ResponseEntity<?> httpMessageNotReadableExceptionHandler(HttpMessageNotReadableException e) {
+        Throwable rootCause = e.getCause();
         if (rootCause instanceof InvalidFormatException invalidFormatException) {
             String fieldName = invalidFormatException.getPath().get(0).getFieldName();
-            String invalidValue = invalidFormatException.getValue().toString();
-            String message = String.format("유효하지 않는 '%s' 값입니다. '%s' 는 %s 중 하나이어야 합니다.",
-                    invalidValue, fieldName, Arrays.toString(DeliveryType.values()));
+            String message = String.format("유효하지 않는 '%s' 값입니다.", fieldName);
             return ResponseEntity.badRequest().body(message);
         }
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(CommonErrorCode.INVALID_INPUT_VALUE);

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
@@ -1,10 +1,14 @@
 package com.pickple.delivery.infrastructure.repository;
 
+import com.pickple.delivery.domain.model.enums.DeliveryStatus;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.domain.repository.DeliveryRepository;
 import com.pickple.delivery.domain.model.Delivery;
 import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface DeliveryMongoRepository extends DeliveryRepository,
@@ -21,4 +25,16 @@ public interface DeliveryMongoRepository extends DeliveryRepository,
 
     @Override
     void deleteById(@Nonnull UUID deliveryId);
+
+    @Override
+    @Nonnull
+    Page<Delivery> findAll(@Nonnull Pageable pageable);
+
+    Page<Delivery> findByCarrierName(String carrier, Pageable pageable);
+
+    Optional<Delivery> findByTrackingNumber(String trackingNumber);
+
+    Page<Delivery> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
+
+    Page<Delivery> findByDeliveryType(DeliveryType deliveryType, Pageable pageable);
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -63,7 +63,7 @@ public class DeliveryController {
                 deliveryService.getDeliveryInfo(deliveryId)));
     }
 
-    @PreAuthorize("hasAnyAuthority('MASTER')")
+    @PreAuthorize("hasAuthority('MASTER')")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<Delivery>>> getAllDeliveryInfo(
             @PageableDefault(

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -14,6 +14,7 @@ import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.presentation.request.DeliveryDetailCreateRequest;
 import com.pickple.delivery.presentation.request.DeliveryStartRequest;
+import com.pickple.delivery.presentation.request.DeliveryUpdateRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -81,6 +83,15 @@ public class DeliveryController {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송 경로가 등록되었습니다.",
                 deliveryDetailService.createDeliveryDetail(
                         DeliveryDetailMapper.convertCreateRequestToDto(deliveryId, request))));
+    }
+
+    @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
+    @PutMapping("/{delivery_id}")
+    public ResponseEntity<ApiResponse<DeliveryInfoResponseDto>> updateDelivery(
+            @PathVariable("delivery_id") UUID deliveryId,
+            @Valid @RequestBody DeliveryUpdateRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송이 수정되었습니다.",
+                deliveryService.updateDelivery(deliveryId, DeliveryMapper.convertUpdateRequestToDto(request))));
     }
 
     @PreAuthorize("hasAuthority('MASTER')")

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -9,11 +9,18 @@ import com.pickple.delivery.application.mapper.DeliveryDetailMapper;
 import com.pickple.delivery.application.mapper.DeliveryMapper;
 import com.pickple.delivery.application.service.DeliveryApplicationService;
 import com.pickple.delivery.application.service.DeliveryDetailApplicationService;
+import com.pickple.delivery.domain.model.Delivery;
+import com.pickple.delivery.domain.model.enums.DeliveryStatus;
+import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.presentation.request.DeliveryDetailCreateRequest;
 import com.pickple.delivery.presentation.request.DeliveryStartRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,6 +31,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -53,6 +61,18 @@ public class DeliveryController {
                 deliveryService.getDeliveryInfo(deliveryId)));
     }
 
+    @PreAuthorize("hasAnyAuthority('MASTER')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<Delivery>>> getAllDeliveryInfo(
+            @PageableDefault(
+                    size = 10,
+                    sort = {"createdAt", "updatedAt"},
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송 조회에 성공하였습니다.",
+                deliveryService.getAllDelivery(pageable)));
+    }
+
     @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
     @PostMapping("/{delivery_id}/details")
     public ResponseEntity<ApiResponse<DeliveryDetailCreateResponseDto>> createDeliveryDetail(
@@ -67,9 +87,54 @@ public class DeliveryController {
     @DeleteMapping("/{delivery_id}")
     public ResponseEntity<ApiResponse<DeliveryDeleteResponseDto>> deleteDeliveryDetail(
             @PathVariable("delivery_id") UUID deliveryId) {
-        String deleter = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String deleter = (String) SecurityContextHolder.getContext().getAuthentication()
+                .getPrincipal();
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "성공적으로 삭제되었습니다.",
                 deliveryService.deleteDelivery(deliveryId, deleter)));
+    }
+
+    // 배송사 기준 검색
+    @PreAuthorize("hasAuthority('MASTER')")
+    @GetMapping("/carrier")
+    public ResponseEntity<ApiResponse<Page<Delivery>>> getDeliveriesByCarrier(
+            @RequestParam String value,
+            @PageableDefault(size = 10, sort = {"createdAt",
+                    "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Delivery> result = deliveryService.getDeliveriesByCarrier(value, pageable);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송사 기준 조회에 성공하였습니다.", result));
+    }
+
+    // 배송 상태 기준 검색
+    @PreAuthorize("hasAuthority('MASTER')")
+    @GetMapping("/status")
+    public ResponseEntity<ApiResponse<Page<Delivery>>> getDeliveriesByStatus(
+            @RequestParam DeliveryStatus value,
+            @PageableDefault(size = 10, sort = {"createdAt",
+                    "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Delivery> result = deliveryService.getDeliveriesByStatus(value, pageable);
+        return ResponseEntity.ok(
+                ApiResponse.success(HttpStatus.OK, "배송 상태 기준 조회에 성공하였습니다.", result));
+    }
+
+    // 배송 유형 기준 검색
+    @PreAuthorize("hasAuthority('MASTER')")
+    @GetMapping("/type")
+    public ResponseEntity<ApiResponse<Page<Delivery>>> getDeliveriesByDeliveryType(
+            @RequestParam DeliveryType value,
+            @PageableDefault(size = 10, sort = {"createdAt",
+                    "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Delivery> result = deliveryService.getDeliveriesByDeliveryType(value, pageable);
+        return ResponseEntity.ok(
+                ApiResponse.success(HttpStatus.OK, "배송 유형 기준 조회에 성공하였습니다.", result));
+    }
+
+    // 송장 번호 기준 검색
+    @PreAuthorize("hasAuthority('MASTER')")
+    @GetMapping("/tracking-number")
+    public ResponseEntity<ApiResponse<DeliveryInfoResponseDto>> getDeliveriesByTrackingNumber(
+            @RequestParam String value) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "송장번호 조회에 성공하였습니다.",
+                deliveryService.getDeliveriesByTrackingNumber(value)));
     }
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/request/DeliveryUpdateRequest.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/request/DeliveryUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.pickple.delivery.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeliveryUpdateRequest {
+
+    @NotBlank
+    private String carrierName;
+
+    @NotBlank
+    private String deliveryType;
+
+    @NotBlank
+    private String trackingNumber;
+
+    @NotBlank
+    private String deliveryStatus;
+
+    @NotBlank
+    private String deliveryRequirement;
+
+    @NotBlank
+    private String recipientName;
+
+    @NotBlank
+    private String recipientAddress;
+
+    @NotBlank
+    private String recipientContact;
+
+}


### PR DESCRIPTION
close #56 

## 📌 필독 내용

- 배송 검색, 전체 조회 (페이지네이션), 배송 수정 API를 구현합니다.
- 위 API는 모두 `MASTER` 권한만 수행 가능합니다.

## ✨ PR 세부 내용

- 배송 수정 요청 : `PUT api/v1/deliveries/{delivery_id}`
- 배송 삭제 요청 : `DELETE api/v1/deliveries/{delivery_id}`
- 배송 전체 요청: `GET /api/v1/deliveries?page={page}&size={size}&sort={createdAt,DESC}`
- 배송사 이름 검색: `GET /api/v1/deliveries/carrier?value=LOZEN`
- 송장 번호 기준 검색: `GET /api/v1/deliveries/type?value=COURIER`
- 배송 상황 기준 검색: `GET /api/v1/deliveries/tracking-number?value=TRACK-13707`
- 배송 유형 기준 검색: `GET /api/v1/deliveries/type?value=COURIER`

수정 요청 DTO
```json
{
  "carrierName": "로젠택배",
  "deliveryType": "택배 배송",
  "trackingNumber": "TRACK-12345",
  "deliveryStatus": "배송준비중",
  "deliveryRequirement": "문 앞에 놔주세요.",
  "recipientName": "홍길동",
  "recipientAddress": "서울특별시 강남구",
  "recipientContact": "010-1234-5678"
}
```
