### PR TITLE
feat: 배송 상태 조회 API 구현

### DIFF
--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/response/DeliveryStatusResponseDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/response/DeliveryStatusResponseDto.java
@@ -1,0 +1,12 @@
+package com.pickple.delivery.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryStatusResponseDto {
+
+    private String status;
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryApplicationService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryApplicationService.java
@@ -9,6 +9,7 @@ import com.pickple.delivery.application.dto.DeliveryInfoDto;
 import com.pickple.delivery.application.dto.request.DeliveryUpdateRequestDto;
 import com.pickple.delivery.application.dto.response.DeliveryDeleteResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
+import com.pickple.delivery.application.dto.response.DeliveryStatusResponseDto;
 import com.pickple.delivery.application.events.DeliveryCreateResponseEvent;
 import com.pickple.delivery.application.dto.request.DeliveryStartRequestDto;
 import com.pickple.delivery.application.dto.response.DeliveryStartResponseDto;
@@ -111,6 +112,14 @@ public class DeliveryApplicationService {
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
         return createDeliveryInfoResponseDto(delivery);
+    }
+
+    @Transactional(readOnly = true)
+    public DeliveryStatusResponseDto getDeliveryStatus(UUID deliveryId) {
+        log.info("배송 상태 조회 요청을 처리합니다. 배송 ID: {}", deliveryId);
+        Delivery delivery = deliveryRepository.findById(deliveryId)
+                .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+        return new DeliveryStatusResponseDto(delivery.getDeliveryStatus().getStatus());
     }
 
     @Transactional(readOnly = true)

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -23,7 +24,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class Delivery extends BaseEntity {
+public class Delivery extends BaseEntity implements Persistable<UUID> {
 
     @Id
     @Field("delivery_id")
@@ -99,5 +100,15 @@ public class Delivery extends BaseEntity {
         this.recipientName = dto.getRecipientName();
         this.recipientAddress = dto.getRecipientAddress();
         this.recipientContact = dto.getRecipientContact();
+    }
+
+    @Override
+    public UUID getId() {
+        return deliveryId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return getCreatedAt() == null;
     }
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/config/SecurityConfig.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class);
 
         http.authorizeHttpRequests(authorize ->
-                authorize.anyRequest().authenticated()
+                authorize.requestMatchers("/actuator/**").permitAll().anyRequest().authenticated()
         );
         return http.build();
     }

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/security/CustomAuthenticationFilter.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/security/CustomAuthenticationFilter.java
@@ -37,10 +37,6 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                    authorities
             );
             SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        } else {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            return;
         }
         filterChain.doFilter(request, response);
     }

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -5,6 +5,7 @@ import com.pickple.delivery.application.dto.response.DeliveryDeleteResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryDetailCreateResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryStartResponseDto;
+import com.pickple.delivery.application.dto.response.DeliveryStatusResponseDto;
 import com.pickple.delivery.application.mapper.DeliveryDetailMapper;
 import com.pickple.delivery.application.mapper.DeliveryMapper;
 import com.pickple.delivery.application.service.DeliveryApplicationService;
@@ -102,6 +103,14 @@ public class DeliveryController {
                 .getPrincipal();
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "성공적으로 삭제되었습니다.",
                 deliveryService.deleteDelivery(deliveryId, deleter)));
+    }
+
+    @PreAuthorize("hasAuthority('MASTER')")
+    @GetMapping("/{delivery_id}/status")
+    public ResponseEntity<ApiResponse<DeliveryStatusResponseDto>> getDeliveryStatus(
+            @PathVariable("delivery_id") UUID deliveryId) {
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송 상태 조회에 성공하였습니다.",
+                deliveryService.getDeliveryStatus(deliveryId)));
     }
 
     // 배송사 기준 검색


### PR DESCRIPTION
close #63 .

## 📌 필독 내용

- 배송 상태 조회 API를 구현합니다. (예시: `GET /api/v1/deliveries/ec8a48bd-13e2-4c29-b687-22d89f3f3d4d/status`)
- `MASTER`만 가능합니다.
- 추가적으로, grafana가 모니터링 하기 위해 actuator/prometheus의 경로를 Security에서 허용합니다.

## ✨ PR 세부 내용
배송 상태 조회 요청 Json 예시

```json
{
    "status": "OK",
    "message": "배송 상태 조회에 성공하였습니다.",
    "data": {
        "status": "PENDING"
    }
}
```
