### PR TITLE
refactor: #79 지연로딩으로 변경

### DIFF
--- a/commerce-service/src/main/java/com/pickple/commerceservice/domain/model/OrderDetail.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/domain/model/OrderDetail.java
@@ -30,7 +30,7 @@ public class OrderDetail extends BaseEntity {
     @Column(name = "order_quantity", nullable = false)
     private Long orderQuantity;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 

--- a/commerce-service/src/main/java/com/pickple/commerceservice/domain/model/PreOrderDetails.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/domain/model/PreOrderDetails.java
@@ -19,7 +19,7 @@ public class PreOrderDetails extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID preOrderId;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 


### PR DESCRIPTION
## 📌 필독 내용

- 상품/주문/예약구매 엔티티 연관관계 지연로딩으로 변경

</br>

## ✨ PR 세부 내용

- 이전 쿼리에서는 product_id, created_at, deleted_at 등의 필드가 중복으로 조회되었지만, 현재는 각각의 테이블에서 필요한 필드만 조회하도록 변경됨
- 이전에는 pre_order_details와 products 테이블을 조인하여 데이터를 가져왔지만, 이제는 조인이 제거되고 pre_order_details에서 product_id를 직접 조회
