### PR TITLE
feat: 배송 서비스 성능 개선 

### DIFF
--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(':common-module')
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryDetailInfoDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/DeliveryDetailInfoDto.java
@@ -1,12 +1,13 @@
 package com.pickple.delivery.application.dto;
 
+import java.io.Serializable;
 import java.util.Date;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class DeliveryDetailInfoDto {
+public class DeliveryDetailInfoDto implements Serializable {
 
     private Date deliveryDetailTime;
 

--- a/delivery-service/src/main/java/com/pickple/delivery/application/dto/response/DeliveryInfoResponseDto.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/dto/response/DeliveryInfoResponseDto.java
@@ -1,6 +1,7 @@
 package com.pickple.delivery.application.dto.response;
 
 import com.pickple.delivery.application.dto.DeliveryDetailInfoDto;
+import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -8,7 +9,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class DeliveryInfoResponseDto {
+public class DeliveryInfoResponseDto implements Serializable {
 
     private UUID deliveryId;
 

--- a/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
@@ -99,4 +99,13 @@ public class DeliveryMapper {
                 .trackingNumber(request.getTrackingNumber())
                 .build();
     }
+
+    public static DeliveryInfoResponseDto convertEntityToInfoResponseDto(Delivery delivery) {
+        DeliveryInfoDto deliveryInfoDto = DeliveryMapper.convertEntityToInfoDto(delivery);
+        List<DeliveryDetailInfoDto> deliveryDetailInfoDtoList = delivery.getDeliveryDetails()
+                .stream().map(DeliveryDetailMapper::convertEntityToInfoDto).toList();
+        return DeliveryMapper.createDeliveryInfoResponseDto(deliveryInfoDto,
+                deliveryDetailInfoDtoList);
+    }
+
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryDetailApplicationService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryDetailApplicationService.java
@@ -1,9 +1,11 @@
 package com.pickple.delivery.application.service;
 
+import static com.pickple.delivery.infrastructure.config.RedisConfig.CACHE_PREFIX;
+
 import com.pickple.common_module.exception.CustomException;
 import com.pickple.delivery.application.dto.request.DeliveryDetailCreateRequestDto;
-import com.pickple.delivery.application.dto.response.DeliveryDetailCreateResponseDto;
-import com.pickple.delivery.application.mapper.DeliveryDetailMapper;
+import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
+import com.pickple.delivery.application.mapper.DeliveryMapper;
 import com.pickple.delivery.domain.model.Delivery;
 import com.pickple.delivery.domain.model.DeliveryDetail;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
@@ -11,6 +13,7 @@ import com.pickple.delivery.domain.repository.DeliveryRepository;
 import com.pickple.delivery.exception.DeliveryErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +25,8 @@ public class DeliveryDetailApplicationService {
     private final DeliveryRepository deliveryRepository;
 
     @Transactional
-    public DeliveryDetailCreateResponseDto createDeliveryDetail(
+    @CachePut(value = CACHE_PREFIX, key = "#dto.deliveryId")
+    public DeliveryInfoResponseDto createDeliveryDetail(
             DeliveryDetailCreateRequestDto dto) {
         Delivery delivery = deliveryRepository.findById(dto.getDeliveryId())
                 .orElseThrow(() -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
@@ -37,8 +41,7 @@ public class DeliveryDetailApplicationService {
         log.info("새로운 DeliveryDetail 을 생성합니다. 요청 정보: {}", dto);
         DeliveryDetail deliveryDetail = DeliveryDetail.createFrom(dto);
         delivery.addDeliveryDetail(deliveryDetail);
-        deliveryRepository.save(delivery);
-        return DeliveryDetailMapper.convertEntityToCreateResponseDto(deliveryDetail);
+        return DeliveryMapper.convertEntityToInfoResponseDto(delivery);
     }
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
@@ -66,10 +66,6 @@ public class Delivery extends BaseEntity implements Persistable<UUID> {
     @Builder.Default
     private List<DeliveryDetail> deliveryDetails = new ArrayList<>();
 
-    @Field("is_deleted")
-    @Builder.Default
-    private Boolean isDeleted = false;
-
     public static Delivery createFrom(DeliveryCreateRequestDto dto) {
         return Delivery.builder()
                 .orderId(dto.getOrderId())

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
@@ -1,5 +1,6 @@
 package com.pickple.delivery.domain.repository;
 
+import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
 import com.pickple.delivery.domain.model.Delivery;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.model.enums.DeliveryType;
@@ -15,7 +16,7 @@ public interface DeliveryRepository {
 
     Optional<Delivery> findById(UUID deliveryId);
 
-    Optional<Delivery> findByTrackingNumber(String trackingNumber);
+    Optional<DeliveryInfoResponseDto> findByTrackingNumber(String trackingNumber);
 
     boolean existsById(@Nonnull UUID deliveryId);
 
@@ -23,10 +24,12 @@ public interface DeliveryRepository {
 
     Page<Delivery> findAll(Pageable pageable);
 
-    Page<Delivery> findByCarrierName(String carrier, Pageable pageable);
+    Page<DeliveryInfoResponseDto> findInfoAll(Pageable pageable);
 
-    Page<Delivery> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
+    Page<DeliveryInfoResponseDto> findByCarrierName(String carrier, Pageable pageable);
 
-    Page<Delivery> findByDeliveryType(DeliveryType deliveryType, Pageable pageable);
+    Page<DeliveryInfoResponseDto> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
+
+    Page<DeliveryInfoResponseDto> findByDeliveryType(DeliveryType deliveryType, Pageable pageable);
 
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/config/RedisConfig.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package com.pickple.delivery.infrastructure.config;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    public static final String CACHE_PREFIX = "deliveryCache";
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new JdkSerializationRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(
+            RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration configuration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofHours(2))
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(SerializationPair.fromSerializer(new JdkSerializationRedisSerializer()));
+
+        return RedisCacheManager
+                .builder(redisConnectionFactory)
+                .cacheDefaults(configuration)
+                .build();
+    }
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
@@ -30,9 +30,6 @@ public interface DeliveryMongoRepository extends DeliveryRepository,
     @Query(value = "{}", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
     Page<DeliveryInfoResponseDto> findInfoAll(Pageable pageable);
 
-    @Nonnull
-    Page<Delivery> findByIsDeletedFalse(@Nonnull Pageable pageable);
-
     @Query(value = "{ 'carrierName' : ?0 }", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
     Page<DeliveryInfoResponseDto> findByCarrierName(String carrierName, Pageable pageable);
 

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
@@ -1,5 +1,6 @@
 package com.pickple.delivery.infrastructure.repository;
 
+import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.domain.repository.DeliveryRepository;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface DeliveryMongoRepository extends DeliveryRepository,
         MongoRepository<Delivery, UUID> {
@@ -17,7 +19,6 @@ public interface DeliveryMongoRepository extends DeliveryRepository,
     @Override
     <S extends Delivery> @Nonnull S save(@Nonnull S entity);
 
-    @Override
     @Nonnull Optional<Delivery> findById(@Nonnull UUID deliveryId);
 
     @Override
@@ -26,15 +27,22 @@ public interface DeliveryMongoRepository extends DeliveryRepository,
     @Override
     void deleteById(@Nonnull UUID deliveryId);
 
-    @Override
+    @Query(value = "{}", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
+    Page<DeliveryInfoResponseDto> findInfoAll(Pageable pageable);
+
     @Nonnull
-    Page<Delivery> findAll(@Nonnull Pageable pageable);
+    Page<Delivery> findByIsDeletedFalse(@Nonnull Pageable pageable);
 
-    Page<Delivery> findByCarrierName(String carrier, Pageable pageable);
+    @Query(value = "{ 'carrierName' : ?0 }", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
+    Page<DeliveryInfoResponseDto> findByCarrierName(String carrierName, Pageable pageable);
 
-    Optional<Delivery> findByTrackingNumber(String trackingNumber);
+    @Query(value = "{ 'trackingNumber' : ?0 }", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
+    Optional<DeliveryInfoResponseDto> findByTrackingNumber(String trackingNumber);
 
-    Page<Delivery> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
+    @Query(value = "{ 'deliveryStatus' : ?0 }", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
+    Page<DeliveryInfoResponseDto> findByDeliveryStatus(DeliveryStatus deliveryStatus, Pageable pageable);
 
-    Page<Delivery> findByDeliveryType(DeliveryType deliveryType, Pageable pageable);
+    @Query(value = "{ 'deliveryType' : ?0 }", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
+    Page<DeliveryInfoResponseDto> findByDeliveryType(DeliveryType deliveryType, Pageable pageable);
+
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -2,7 +2,6 @@ package com.pickple.delivery.presentation.controller;
 
 import com.pickple.common_module.presentation.dto.ApiResponse;
 import com.pickple.delivery.application.dto.response.DeliveryDeleteResponseDto;
-import com.pickple.delivery.application.dto.response.DeliveryDetailCreateResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryInfoResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryStartResponseDto;
 import com.pickple.delivery.application.dto.response.DeliveryStatusResponseDto;
@@ -10,7 +9,6 @@ import com.pickple.delivery.application.mapper.DeliveryDetailMapper;
 import com.pickple.delivery.application.mapper.DeliveryMapper;
 import com.pickple.delivery.application.service.DeliveryApplicationService;
 import com.pickple.delivery.application.service.DeliveryDetailApplicationService;
-import com.pickple.delivery.domain.model.Delivery;
 import com.pickple.delivery.domain.model.enums.DeliveryStatus;
 import com.pickple.delivery.domain.model.enums.DeliveryType;
 import com.pickple.delivery.presentation.request.DeliveryDetailCreateRequest;
@@ -66,19 +64,19 @@ public class DeliveryController {
 
     @PreAuthorize("hasAuthority('MASTER')")
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<Delivery>>> getAllDeliveryInfo(
+    public ResponseEntity<ApiResponse<Page<DeliveryInfoResponseDto>>> getAllDeliveryInfo(
             @PageableDefault(
                     size = 10,
                     sort = {"createdAt", "updatedAt"},
                     direction = Sort.Direction.DESC
             ) Pageable pageable) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송 조회에 성공하였습니다.",
-                deliveryService.getAllDelivery(pageable)));
+                deliveryService.getAllDeliveryInfo(pageable)));
     }
 
     @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
     @PostMapping("/{delivery_id}/details")
-    public ResponseEntity<ApiResponse<DeliveryDetailCreateResponseDto>> createDeliveryDetail(
+    public ResponseEntity<ApiResponse<DeliveryInfoResponseDto>> createDeliveryDetail(
             @PathVariable("delivery_id") UUID deliveryId,
             @Valid @RequestBody DeliveryDetailCreateRequest request) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송 경로가 등록되었습니다.",
@@ -116,22 +114,22 @@ public class DeliveryController {
     // 배송사 기준 검색
     @PreAuthorize("hasAuthority('MASTER')")
     @GetMapping("/carrier")
-    public ResponseEntity<ApiResponse<Page<Delivery>>> getDeliveriesByCarrier(
+    public ResponseEntity<ApiResponse<Page<DeliveryInfoResponseDto>>> getDeliveriesByCarrier(
             @RequestParam String value,
             @PageableDefault(size = 10, sort = {"createdAt",
                     "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<Delivery> result = deliveryService.getDeliveriesByCarrier(value, pageable);
+        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByCarrier(value, pageable);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송사 기준 조회에 성공하였습니다.", result));
     }
 
     // 배송 상태 기준 검색
     @PreAuthorize("hasAuthority('MASTER')")
     @GetMapping("/status")
-    public ResponseEntity<ApiResponse<Page<Delivery>>> getDeliveriesByStatus(
+    public ResponseEntity<ApiResponse<Page<DeliveryInfoResponseDto>>> getDeliveriesByStatus(
             @RequestParam DeliveryStatus value,
             @PageableDefault(size = 10, sort = {"createdAt",
                     "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<Delivery> result = deliveryService.getDeliveriesByStatus(value, pageable);
+        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByStatus(value, pageable);
         return ResponseEntity.ok(
                 ApiResponse.success(HttpStatus.OK, "배송 상태 기준 조회에 성공하였습니다.", result));
     }
@@ -139,11 +137,11 @@ public class DeliveryController {
     // 배송 유형 기준 검색
     @PreAuthorize("hasAuthority('MASTER')")
     @GetMapping("/type")
-    public ResponseEntity<ApiResponse<Page<Delivery>>> getDeliveriesByDeliveryType(
+    public ResponseEntity<ApiResponse<Page<DeliveryInfoResponseDto>>> getDeliveriesByDeliveryType(
             @RequestParam DeliveryType value,
             @PageableDefault(size = 10, sort = {"createdAt",
                     "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<Delivery> result = deliveryService.getDeliveriesByDeliveryType(value, pageable);
+        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByDeliveryType(value, pageable);
         return ResponseEntity.ok(
                 ApiResponse.success(HttpStatus.OK, "배송 유형 기준 조회에 성공하였습니다.", result));
     }

--- a/delivery-service/src/main/resources/application-dev.yml
+++ b/delivery-service/src/main/resources/application-dev.yml
@@ -9,6 +9,9 @@ spring:
       username: delivery_db
       password: delivery
       authentication-database: admin
+    redis:
+      host: localhost
+      port: 6379
 
   kafka:
     bootstrap-servers: localhost:9092


### PR DESCRIPTION
resolve #81 

## 📌 필독 내용

- Redis 연동
- 배송 단일 조회 시 Redis 캐싱에서 확인
- 배송 경로가 업데이트 된 DTO만 캐싱, TTL은 2시간
- projection 쿼리 사용

## ✨ PR 세부 내용

- redis key prefix: `deliveryCache::`
