### PR TITLE
fix: Notification service 실행 오류 해결 - 엔티티 참조 변수명 수정

### DIFF
--- a/notification-service/src/main/java/com/pickple/notification_service/domain/model/Channel.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/domain/model/Channel.java
@@ -32,7 +32,7 @@ public class Channel extends BaseEntity {
     @Column(name="description")
     private String description;
 
-    @OneToMany(mappedBy = "Channel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Notification> notifications;
 
     public Channel(ChannelCreateReqDto reqDto) {


### PR DESCRIPTION
## 📌 필독 내용

- Notification - Channel 엔티티 간 양방향 설정 중 오타 수정


## ✨ PR 세부 내용

- Notification 엔티티에서 Channel 엔티티를 참조하는 필드를 지정할 때 mappedBy에 쓴 변수명이 Notification에 선언한 변수명과 달라서 오류 발생 → 변수명 수정해서 해결 
