### PR TITLE
feat: #92 주문 ID로 배송 조회 API 구현

### DIFF
--- a/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/mapper/DeliveryMapper.java
@@ -44,7 +44,7 @@ public class DeliveryMapper {
         return DeliveryStartResponseDto.builder()
                 .deliveryId(delivery.getDeliveryId())
                 .carrierName(delivery.getCarrierName())
-                .deliveryType(delivery.getDeliveryType().getTypeName())
+                .deliveryType(delivery.getDeliveryType() != null ? delivery.getDeliveryType().getTypeName() : null)
                 .trackingNumber(delivery.getTrackingNumber())
                 .orderId(delivery.getOrderId())
                 .deliveryStatus(delivery.getDeliveryStatus().getStatus())

--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryApplicationService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryApplicationService.java
@@ -109,6 +109,17 @@ public class DeliveryApplicationService {
     }
 
     @Transactional(readOnly = true)
+    public DeliveryStartResponseDto getDeliveryInfoByOrderId(UUID orderId) {
+        log.info("배송 정보 요청을 처리합니다. 주문 ID: {}", orderId);
+        Delivery delivery = deliveryRepository.findByOrderId(orderId).orElseThrow(
+                () -> new CustomException(DeliveryErrorCode.DELIVERY_NOT_FOUND)
+        );
+
+        log.info("배송 정보 요청이 성공적으로 완료되었습니다. 주문 ID: {}", delivery.getOrderId());
+        return DeliveryMapper.convertEntityToStartResponseDto(delivery);
+    }
+
+    @Transactional(readOnly = true)
     public DeliveryInfoResponseDto getDeliveryInfo(UUID deliveryId) {
         log.info("배송 정보 조회 요청을 처리합니다. 배송 ID: {}", deliveryId);
 

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/repository/DeliveryRepository.java
@@ -16,6 +16,8 @@ public interface DeliveryRepository {
 
     Optional<Delivery> findById(UUID deliveryId);
 
+    Optional<Delivery> findByOrderId(UUID orderId);
+
     Optional<DeliveryInfoResponseDto> findByTrackingNumber(String trackingNumber);
 
     boolean existsById(@Nonnull UUID deliveryId);

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/repository/DeliveryMongoRepository.java
@@ -27,6 +27,8 @@ public interface DeliveryMongoRepository extends DeliveryRepository,
     @Override
     void deleteById(@Nonnull UUID deliveryId);
 
+    Optional<Delivery> findByOrderId(UUID orderId);
+
     @Query(value = "{}", fields = "{ 'deliveryId' : 1, 'orderId' : 1, 'carrierName' : 1, 'deliveryType' : 1, 'trackingNumber' : 1, 'deliveryStatus' : 1, 'deliveryRequirement' : 1, 'recipientName' : 1, 'recipientAddress' : 1, 'recipientContact' : 1, 'deliveryDetails' : 1 }")
     Page<DeliveryInfoResponseDto> findInfoAll(Pageable pageable);
 

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -62,6 +62,15 @@ public class DeliveryController {
                 deliveryService.getDeliveryInfo(deliveryId)));
     }
 
+    @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<ApiResponse<DeliveryStartResponseDto>> getDeliveryInfoByOrderId(
+            @PathVariable("orderId") UUID orderId) {
+        return ResponseEntity.ok(
+                ApiResponse.success(HttpStatus.OK, "배송 조회에 성공하였습니다.",
+                        deliveryService.getDeliveryInfoByOrderId(orderId)));
+    }
+
     @PreAuthorize("hasAuthority('MASTER')")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<DeliveryInfoResponseDto>>> getAllDeliveryInfo(
@@ -90,7 +99,8 @@ public class DeliveryController {
             @PathVariable("delivery_id") UUID deliveryId,
             @Valid @RequestBody DeliveryUpdateRequest request) {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송이 수정되었습니다.",
-                deliveryService.updateDelivery(deliveryId, DeliveryMapper.convertUpdateRequestToDto(request))));
+                deliveryService.updateDelivery(deliveryId,
+                        DeliveryMapper.convertUpdateRequestToDto(request))));
     }
 
     @PreAuthorize("hasAuthority('MASTER')")
@@ -118,7 +128,8 @@ public class DeliveryController {
             @RequestParam String value,
             @PageableDefault(size = 10, sort = {"createdAt",
                     "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByCarrier(value, pageable);
+        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByCarrier(value,
+                pageable);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, "배송사 기준 조회에 성공하였습니다.", result));
     }
 
@@ -129,7 +140,8 @@ public class DeliveryController {
             @RequestParam DeliveryStatus value,
             @PageableDefault(size = 10, sort = {"createdAt",
                     "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByStatus(value, pageable);
+        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByStatus(value,
+                pageable);
         return ResponseEntity.ok(
                 ApiResponse.success(HttpStatus.OK, "배송 상태 기준 조회에 성공하였습니다.", result));
     }
@@ -141,7 +153,8 @@ public class DeliveryController {
             @RequestParam DeliveryType value,
             @PageableDefault(size = 10, sort = {"createdAt",
                     "updatedAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByDeliveryType(value, pageable);
+        Page<DeliveryInfoResponseDto> result = deliveryService.getDeliveriesByDeliveryType(value,
+                pageable);
         return ResponseEntity.ok(
                 ApiResponse.success(HttpStatus.OK, "배송 유형 기준 조회에 성공하였습니다.", result));
     }


### PR DESCRIPTION
resolve 92.

## 📌 필독 내용

Order Id로 배송 정보 조회하는 API를 구현합니다.

예시 요청 URL: `http://localhost:19096/api/v1/deliveries/orders/9f4dcb8a-6d3e-4a9b-a013-98d88a9cde8f`

응답 JSON 예시

```json
{
    "status": "OK",
    "message": "배송 조회에 성공하였습니다.",
    "data": {
        "deliveryId": "6f9eeb93-7ae3-4836-8ff9-82f75e2323a2",
        "orderId": "9f4dcb8a-6d3e-4a9b-a013-98d88a9cde8f",
        "carrierName": null,
        "deliveryType": null,
        "trackingNumber": null,
        "deliveryStatus": "배송준비중",
        "deliveryRequirement": "문 앞에 놔주세요.",
        "recipientName": "김아무개",
        "recipientAddress": "서울",
        "recipientContact": "010-1234-5678"
    }
}
```

