### PR TITLE
chore: 관리자용 슬랙 url 요청 API 구현 및 수신 이메일 받는 User feign 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,4 +228,4 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle,java,intellij,macos,windows
 
-.env
+docker/.env

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -37,6 +37,8 @@ dependencyManagement {
 	}
 }
 
+task prepareKotlinBuildScriptModel {}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -37,7 +37,6 @@ dependencyManagement {
 	}
 }
 
-task prepareKotlinBuildScriptModel {}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -58,7 +58,6 @@ dependencyManagement {
 	}
 }
 
-task prepareKotlinBuildScriptModel {}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -58,6 +58,8 @@ dependencyManagement {
 	}
 }
 
+task prepareKotlinBuildScriptModel {}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/notification-service/src/main/java/com/pickple/notification_service/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/NotificationServiceApplication.java
@@ -2,7 +2,9 @@ package com.pickple.notification_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class NotificationServiceApplication {
 

--- a/notification-service/src/main/java/com/pickple/notification_service/application/service/EmailService.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/application/service/EmailService.java
@@ -8,6 +8,7 @@ import com.pickple.notification_service.domain.repository.ChannelRepository;
 import com.pickple.notification_service.domain.repository.NotificationRepository;
 import com.pickple.notification_service.exception.ChannelErrorCode;
 import com.pickple.notification_service.exception.NotificationErrorCode;
+import com.pickple.notification_service.infrastructure.feign.UserFeignClient;
 import com.pickple.notification_service.infrastructure.messaging.NotificationEventProducer;
 import com.pickple.notification_service.infrastructure.messaging.events.EmailCreateRequestEvent;
 import com.pickple.notification_service.infrastructure.messaging.events.NotificationFailureResponse;
@@ -41,14 +42,19 @@ public class EmailService {
     @Autowired
     private final ChannelRepository channelRepository;
 
+    @Autowired
+    private final UserFeignClient userFeignClient;
+
     // 이메일 전송
     public void sendEmail(EmailCreateRequestEvent event) {
+
+        String toEmail = userFeignClient.getUserEmail(event.getUsername());
 
         try{
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
-            helper.setTo(event.getToEmail());
+            helper.setTo(toEmail);
             helper.setSubject(event.getSubject());
             helper.setText(event.getContent(), true);
             helper.setFrom(event.getSender());

--- a/notification-service/src/main/java/com/pickple/notification_service/infrastructure/feign/UserFeignClient.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/infrastructure/feign/UserFeignClient.java
@@ -1,0 +1,11 @@
+package com.pickple.notification_service.infrastructure.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="user-service")
+public interface UserFeignClient {
+    @GetMapping("/user/api/v1/get-user-email/{username}")
+    String getUserEmail(@PathVariable("username") String username);
+}

--- a/notification-service/src/main/java/com/pickple/notification_service/infrastructure/messaging/events/EmailCreateRequestEvent.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/infrastructure/messaging/events/EmailCreateRequestEvent.java
@@ -15,9 +15,6 @@ public class EmailCreateRequestEvent {
     private String username;
     private String category;
 
-    @NotBlank(message = "수신자의 email을 입력해주세요.")
-    @Email(message="지원하지 않는 형식의 email 입니다.")
-    private String toEmail;
     @NotBlank(message = "제목은 비워둘 수 없습니다.")
     private String subject;
     @NotBlank(message = "본문은 비워둘 수 없습니다.")

--- a/notification-service/src/main/java/com/pickple/notification_service/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/presentation/NotificationController.java
@@ -26,7 +26,7 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @Value("${SLACK_WORKSPACE_URL")
+    @Value("${SLACK_WORKSPACE_URL}")
     private String slackWorkspaceUrl;
 
     @PreAuthorize("hasAuthority('MASTER')")

--- a/notification-service/src/main/java/com/pickple/notification_service/presentation/NotificationController.java
+++ b/notification-service/src/main/java/com/pickple/notification_service/presentation/NotificationController.java
@@ -7,6 +7,7 @@ import com.pickple.notification_service.application.service.NotificationService;
 import com.pickple.notification_service.presentation.request.ChannelCreateReqDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +26,9 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    @Value("${SLACK_WORKSPACE_URL")
+    private String slackWorkspaceUrl;
+
     @PreAuthorize("hasAuthority('MASTER')")
     @DeleteMapping("/{notification_id}")
     public ResponseEntity<Void> deleteNotification(@PathVariable("notification_id") UUID notificationId) {
@@ -34,7 +38,7 @@ public class NotificationController {
     }
 
     @PreAuthorize("hasAnyAuthority('USER', 'MASTER', 'VENDOR_MANAGER')")
-    @GetMapping("/notificationHistory/{username}")
+    @GetMapping("/notification-history/{username}")
     public ResponseEntity<ApiResponse<Page<NotificationRespDto>>> notificationHistory (
             @PathVariable("username") String username,
             @RequestParam(value="page", defaultValue="0") int page,
@@ -54,7 +58,7 @@ public class NotificationController {
     }
 
     @PreAuthorize("hasAuthority('MASTER')")
-    @GetMapping("/getAllNotifications")
+    @GetMapping("/get-all-notifications")
     public ResponseEntity<ApiResponse<Page<NotificationRespDto>>> getAllNotifications(
             @RequestParam(value="page", defaultValue="0") int page,
             @RequestParam(value="size", defaultValue = "10") int size,
@@ -89,6 +93,18 @@ public class NotificationController {
         notificationService.deleteChannel(channelId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasAuthority('MASTER')")
+    @GetMapping("/slack-for-admin")
+    public ResponseEntity<ApiResponse<String>> getSlackUrl(){
+        ApiResponse<String> response = ApiResponse.success(
+                HttpStatus.OK,
+                "관리자용 슬랙 워크 스페이스 url 입니다.",
+                slackWorkspaceUrl
+        );
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -59,7 +59,6 @@ dependencyManagement {
 	}
 }
 
-task prepareKotlinBuildScriptModel {}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/settings/grafana/provisioning/alerting/gf_contactpoint.yml
+++ b/settings/grafana/provisioning/alerting/gf_contactpoint.yml
@@ -7,5 +7,22 @@ contactPoints:
       - uid: ce0eyk36u28zlb
         type: slack
         settings:
+          text: |-
+            {{ define "alerts.message" -}}
+              {{ if .Alerts.Firing -}}
+                {{ len .Alerts.Firing }} firing alert(s)
+                {{ template "alerts.summarize" .Alerts.Firing }}
+              {{- end }}
+              {{- if .Alerts.Resolved -}}
+                {{ len .Alerts.Resolved }} resolved alert(s)
+                {{ template "alerts.summarize" .Alerts.Resolved }}
+              {{- end }}
+            {{- end }}
+            
+            {{ define "alerts.summarize" -}}
+              {{ range . -}}
+              - {{ index .Annotations "summary" }}
+              {{ end }}
+            {{ end }}
           url: ${GF_NOTIFIERS_CONTACTPOINT_URL}
         disableResolveMessage: false


### PR DESCRIPTION
## 📌 필독 내용

- 관리자용 슬랙 url 요청 API 구현 및 수신 이메일 받는 User feign 추가


## ✨ PR 세부 내용

- MASTER 권한의 사용자만 슬랙 워크스페이스 url을 요청 할 수 있도록 API 추가
- 이메일 발송 시 수신자 username으로 이메일 반환받는 feign 추가
- 그라파나 슬랙 메세지 템플릿 수정
