### PR TITLE
fix: delivery detail 수정 시 명시적 save 추가

### DIFF
--- a/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryDetailApplicationService.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/service/DeliveryDetailApplicationService.java
@@ -41,6 +41,7 @@ public class DeliveryDetailApplicationService {
         log.info("새로운 DeliveryDetail 을 생성합니다. 요청 정보: {}", dto);
         DeliveryDetail deliveryDetail = DeliveryDetail.createFrom(dto);
         delivery.addDeliveryDetail(deliveryDetail);
+        deliveryRepository.save(delivery);
         return DeliveryMapper.convertEntityToInfoResponseDto(delivery);
     }
 


### PR DESCRIPTION
## 📌 필독 내용

MongoDB는 영속성 컨텍스트가 없어서 수정 시 다시 저장해줘야 하는데 이를 안 하고 있었네요 ㅠ 