### PR TITLE
feat: 배송 완료 API 구현

### DIFF
--- a/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryEndEvent.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryEndEvent.java
@@ -1,0 +1,15 @@
+package com.pickple.delivery.application.events;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryEndEvent {
+
+    private UUID orderId;
+
+    private UUID deliveryId;
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/domain/model/Delivery.java
@@ -84,6 +84,10 @@ public class Delivery extends BaseEntity implements Persistable<UUID> {
         this.trackingNumber = dto.getTrackingNumber();
     }
 
+    public void endDelivery() {
+        this.deliveryStatus = DeliveryStatus.DELIVERED;
+    }
+
     public void addDeliveryDetail(DeliveryDetail detail) {
         this.deliveryDetails.add(detail);
     }

--- a/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/exception/DeliveryErrorCode.java
@@ -17,6 +17,7 @@ public enum DeliveryErrorCode implements ErrorCode {
     DELIVERY_DELETE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "Delivery 삭제에 실패하였습니다."),
     DELIVERY_SAVE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 저장에 실패하였습니다."),
     DELIVERY_ALREADY_START(HttpStatus.BAD_REQUEST, "이미 시작된 배송입니다."),
+    DELIVERY_ALREADY_END(HttpStatus.BAD_REQUEST, "이미 완료된 배송입니다."),
     DELIVERY_NOT_STARTED(HttpStatus.BAD_REQUEST, "배송이 아직 시작되지 않았습니다."),
     DELIVERY_ALREADY_DELIVERED(HttpStatus.BAD_REQUEST, "이미 완료된 배송입니다.");
 

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -168,4 +168,13 @@ public class DeliveryController {
                 deliveryService.getDeliveriesByTrackingNumber(value)));
     }
 
+    @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
+    @PostMapping("/{delivery_id}/end")
+    public ResponseEntity<ApiResponse<Void>> endDelivery(
+            @PathVariable("delivery_id") UUID deliveryId) {
+        deliveryService.endDelivery(deliveryId);
+        return ResponseEntity.ok(
+                ApiResponse.success(HttpStatus.OK, "배송이 완료되었습니다.", null));
+    }
+
 }

--- a/delivery-service/src/main/resources/application-dev.yml
+++ b/delivery-service/src/main/resources/application-dev.yml
@@ -35,6 +35,7 @@ kafka:
     delivery-create-response: delivery-create-response
     delivery-create-failure: delivery-create-failure
     delivery-delete-failure: delivery-delete-failure
+    delivery-end-response: delivery-end-response
 
 server:
   port: 19096

--- a/delivery-service/src/main/resources/application-prod.yml
+++ b/delivery-service/src/main/resources/application-prod.yml
@@ -36,6 +36,7 @@ kafka:
     delivery-create-response: delivery-create-response
     delivery-create-failure: delivery-create-failure
     delivery-delete-failure: delivery-delete-failure
+    delivery-end-response: delivery-end-response
 
 server:
   port: ${DELIVERY_SERVER_PORT}


### PR DESCRIPTION
resolve #102 .

## 📌 필독 내용

- 배송 완료 API를 구현합니다.
- 주문쪽에 주문 완료처리를 하기 위해 Kafka 메시지를 발행합니다.

## ✨ PR 세부 내용

- 요청 URI: `POST /api/v1/deliveries/{delivery_id}/end`
- 카프카 토픽: `delivery-end-response`

응답 이벤트 예시
DeliveryEndEvent
```json
{
	"orderId": "9f4dcb8a-6d3e-4a9b-a013-98d88a9cde8f",
	"deliveryId": "6f9eeb93-7ae3-4836-8ff9-82f75e2323a2"
}
```

