### PR TITLE
feat: 배송 상태 변경 시 알림 메시지 발행 및 배송 삭제 이벤트 발행

### DIFF
--- a/commerce-service/src/main/java/com/pickple/commerceservice/application/service/OrderService.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/application/service/OrderService.java
@@ -209,4 +209,14 @@ public class OrderService {
         return orderRepository.findOrdersByOrderStatus(orderStatus, pageable)
                 .map(OrderSummaryResponseDto::fromEntity);
     }
+
+    /**
+     * 배송아이디로 username 검색
+     */
+    @Transactional(readOnly = true)
+    public String findUsernameByDeliveryId(UUID deliveryId) {
+        return orderRepository.findByDeliveryId(deliveryId).orElseThrow(
+                () -> new CustomException(CommerceErrorCode.ORDER_NOT_FOUND)
+        ).getUsername();
+    }
 }

--- a/commerce-service/src/main/java/com/pickple/commerceservice/domain/repository/OrderRepository.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/domain/repository/OrderRepository.java
@@ -3,6 +3,7 @@ package com.pickple.commerceservice.domain.repository;
 import com.pickple.commerceservice.domain.model.Order;
 import com.pickple.commerceservice.domain.model.OrderDetail;
 import com.pickple.commerceservice.domain.model.OrderStatus;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,5 +23,7 @@ public interface OrderRepository extends JpaRepository<Order, UUID> {
 
     @Query("SELECT o FROM Order o WHERE o.isDelete = false AND o.orderStatus = :orderStatus")
     Page<Order> findOrdersByOrderStatus(OrderStatus orderStatus, Pageable pageable);
+
+    Optional<Order> findByDeliveryId(UUID deliveryId);
 
 }

--- a/commerce-service/src/main/java/com/pickple/commerceservice/infrastructure/feign/DeliveryClient.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/infrastructure/feign/DeliveryClient.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.UUID;
 
-@FeignClient(name = "delivery-service", url = "http://${feign.host.delivery}:19096")
+@FeignClient(name = "delivery-service")
 public interface DeliveryClient {
 
     @GetMapping("/api/v1/deliveries/orders/{orderId}")

--- a/commerce-service/src/main/java/com/pickple/commerceservice/infrastructure/feign/PaymentClient.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/infrastructure/feign/PaymentClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.UUID;
 
-@FeignClient(name = "payment-service", url = "http://${feign.host.payment}:19095")
+@FeignClient(name = "payment-service")
 public interface PaymentClient {
 
     @GetMapping("/api/v1/payments/getPaymentInfo/{order_id}")

--- a/commerce-service/src/main/java/com/pickple/commerceservice/presentation/controller/OrderController.java
+++ b/commerce-service/src/main/java/com/pickple/commerceservice/presentation/controller/OrderController.java
@@ -148,4 +148,16 @@ public class OrderController {
                 ApiResponse.success(HttpStatus.OK, "주문 상태별 조회 성공", orders)
         );
     }
+
+    /**
+     * 배송 아이디로 username 검색
+     */
+    @GetMapping("/deliveries/{deliveryId}/username")
+    @PreAuthorize("hasAnyAuthority('VENDOR_MANAGER', 'MASTER')")
+    public String getUsernameByDeliveryId(
+            @PathVariable("deliveryId") UUID deliveryId,
+            @RequestHeader("X-User-Roles") String role,
+            @RequestHeader("X-User-Name") String username) {
+        return orderService.findUsernameByDeliveryId(deliveryId);
+    }
 }

--- a/commerce-service/src/main/resources/application-dev.yml
+++ b/commerce-service/src/main/resources/application-dev.yml
@@ -52,8 +52,3 @@ kafka:
     delivery-create-request: delivery-create-request
     payment-cancel-request: payment-cancel-request
     delivery-delete-request: delivery-delete-request
-
-feign:
-  host:
-    delivery: localhost
-    payment: localhost

--- a/commerce-service/src/main/resources/application-prod.yml
+++ b/commerce-service/src/main/resources/application-prod.yml
@@ -53,8 +53,3 @@ kafka:
     delivery-create-request: delivery-create-request
     payment-cancel-request: payment-cancel-request
     delivery-delete-request: delivery-delete-request
-
-feign:
-  host:
-    delivery: delivery-service
-    payment: payment-service

--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     // Prometheus
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     implementation project(':common-module')
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/delivery-service/src/main/java/com/pickple/delivery/DeliveryServiceApplication.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/DeliveryServiceApplication.java
@@ -3,6 +3,7 @@ package com.pickple.delivery;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
@@ -11,6 +12,7 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 @EnableSpringDataWebSupport(
         pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO
 )
+@EnableFeignClients
 public class DeliveryServiceApplication {
 
     public static void main(String[] args) {

--- a/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryEndEvent.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/events/DeliveryEndEvent.java
@@ -12,4 +12,6 @@ public class DeliveryEndEvent {
 
     private UUID deliveryId;
 
+    private String status;
+
 }

--- a/delivery-service/src/main/java/com/pickple/delivery/application/events/NotificationSendEvent.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/events/NotificationSendEvent.java
@@ -1,0 +1,18 @@
+package com.pickple.delivery.application.events;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationSendEvent {
+    private String username;
+
+    @Builder.Default
+    private String category = "DELIVERY";
+    private String subject;
+
+    private String content;
+
+    private String sender;
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/application/port/OrderClient.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/application/port/OrderClient.java
@@ -1,0 +1,15 @@
+package com.pickple.delivery.application.port;
+
+import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+public interface OrderClient {
+
+    String getUsernameByDeliveryId(
+            @PathVariable("deliveryId") UUID deliveryId,
+            @RequestHeader("X-User-Roles") String role,
+            @RequestHeader("X-User-Name") String username
+    );
+
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/infrastructure/feign/OrderFeignClient.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/infrastructure/feign/OrderFeignClient.java
@@ -1,0 +1,19 @@
+package com.pickple.delivery.infrastructure.feign;
+
+import com.pickple.delivery.application.port.OrderClient;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "commerce-service")
+public interface OrderFeignClient extends OrderClient {
+
+    @GetMapping("/api/v1/orders/deliveries/{deliveryId}/username")
+    String getUsernameByDeliveryId(
+            @PathVariable("deliveryId") UUID deliveryId,
+            @RequestHeader("X-User-Roles") String role,
+            @RequestHeader("X-User-Name") String username
+    );
+}

--- a/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/pickple/delivery/presentation/controller/DeliveryController.java
@@ -105,7 +105,7 @@ public class DeliveryController {
 
     @PreAuthorize("hasAuthority('MASTER')")
     @DeleteMapping("/{delivery_id}")
-    public ResponseEntity<ApiResponse<DeliveryDeleteResponseDto>> deleteDeliveryDetail(
+    public ResponseEntity<ApiResponse<DeliveryDeleteResponseDto>> deleteDelivery(
             @PathVariable("delivery_id") UUID deliveryId) {
         String deleter = (String) SecurityContextHolder.getContext().getAuthentication()
                 .getPrincipal();

--- a/delivery-service/src/main/resources/application-dev.yml
+++ b/delivery-service/src/main/resources/application-dev.yml
@@ -36,6 +36,7 @@ kafka:
     delivery-create-failure: delivery-create-failure
     delivery-delete-failure: delivery-delete-failure
     delivery-end-response: delivery-end-response
+    email-create-request: email-create-request
 
 server:
   port: 19096

--- a/delivery-service/src/main/resources/application-prod.yml
+++ b/delivery-service/src/main/resources/application-prod.yml
@@ -37,6 +37,7 @@ kafka:
     delivery-create-failure: delivery-create-failure
     delivery-delete-failure: delivery-delete-failure
     delivery-end-response: delivery-end-response
+    email-create-request: email-create-request
 
 server:
   port: ${DELIVERY_SERVER_PORT}


### PR DESCRIPTION
resolve #106

## 📌 필독 내용

- 배송 시작, 종료 시 알림에 `email-create-request` 토픽으로 이벤트 발행
- Order 쪽에 배송아이디로 username 불러오는 API 구현
- 배송 삭제 시 `delivery-end-resposne` 토픽으로 이벤트 발행


